### PR TITLE
refactor Eiffel links serialization (issue #13)

### DIFF
--- a/src/EiffelEvents.Net/Common/JsonHelper.cs
+++ b/src/EiffelEvents.Net/Common/JsonHelper.cs
@@ -15,7 +15,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -72,7 +71,6 @@ namespace EiffelEvents.Net.Common
         }
     }
 
-
     internal class CustomContractResolver : CamelCasePropertyNamesContractResolver
     {
         public static readonly CustomContractResolver Instance = new();
@@ -110,7 +108,9 @@ namespace EiffelEvents.Net.Common
         public CollectionValueProvider(IValueProvider innerProvider, Type collectionType)
         {
             _innerProvider = innerProvider;
-            _defaultValue = Activator.CreateInstance(collectionType);
+            _defaultValue = collectionType.IsInterface || collectionType.IsAbstract
+                ? null
+                : Activator.CreateInstance(collectionType);
         }
 
         public void SetValue(object target, object value)

--- a/src/EiffelEvents.Net/Events/Core/Links/IEiffelSerializedLink.cs
+++ b/src/EiffelEvents.Net/Events/Core/Links/IEiffelSerializedLink.cs
@@ -14,7 +14,7 @@
 
 namespace EiffelEvents.Net.Events.Core.Links
 {
-    public record EiffelSerializedLink
+    public interface IEiffelSerializedLink
     {
         public string Type { get; init; }
         public string Target { get; init; }

--- a/src/EiffelEvents.Net/Events/Core/Links/IEiffelSerializedLinkCollection.cs
+++ b/src/EiffelEvents.Net/Events/Core/Links/IEiffelSerializedLinkCollection.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace EiffelEvents.Net.Events.Core.Links
+{
+    public interface IEiffelSerializedLinkCollection : IList
+    {
+        
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Paris/Shared/EiffelSerializedLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/Shared/EiffelSerializedLink.cs
@@ -1,0 +1,10 @@
+﻿using EiffelEvents.Net.Events.Core.Links;
+
+namespace EiffelEvents.Net.Events.Edition_Paris.Shared
+{
+    public record EiffelSerializedLink : IEiffelSerializedLink
+    {
+        public string Type { get; init; }
+        public string Target { get; init; }
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Paris/Shared/EiffelSerializedLinkCollection.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/Shared/EiffelSerializedLinkCollection.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+using EiffelEvents.Net.Events.Core.Links;
+
+namespace EiffelEvents.Net.Events.Edition_Paris.Shared
+{
+    public class EiffelSerializedLinkCollection : List<EiffelSerializedLink>, IEiffelSerializedLinkCollection
+    {
+    }
+}


### PR DESCRIPTION
### Applicable Issues
This PR resolves #13 

### Description of the Change
We have refactored the `SerializedLinks` property in the base `EiffelEvent` record to implement a new interface `IEiffelSerializedLink` that will provide more extensibility for the upcoming protocol editions.

### Benefits
This design will provide more extensibility for the upcoming protocol editions.


### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fady Kamil engfadykamil.2014@gmail.com

Co-Authored by: @AhmedAbouElfotouh Ahmed Abou Elfotouh ahmed.fotouh@live.com 