### PR TITLE
Serialize empty links

### DIFF
--- a/docs/docfx_project/articles/implement-event.md
+++ b/docs/docfx_project/articles/implement-event.md
@@ -1,6 +1,6 @@
 # Implement Events Checklist
 
-This checklist to follow when implementing events. 
+This checklist is to follow when implementing events. 
 
 1. 
    Create directory for event under `Events/<edition namespace directory>`, for instance **Events / Edition-Paris / EiffelActivityTriggeredEvent**.
@@ -14,8 +14,22 @@ public record EiffelActivityTriggeredEvent
 ```
 
 3. Each Data, Links, and Meta properties has its own class, such as `<EventName>Data`, `<EventName>Links`, and `<EventName>Meta` respectively, e.g `EiffelActivityTriggeredData`, as long as the event itself.
+4. Initialize Data, Meta, and Links properties with `new()`. Although, they are required by the protocol schemas for all events, sometimes are not applicable to some events that have no Data or Links required such as `EiffelArtifactReusedEvent` that has no required Data (internal properties) required,  `EiffelActivityTriggeredEvent,` and `EiffelAnnouncementPublishedEvent` that has no required Links  (internal properties).
 
-4. The event should implement `FromJson` method to pass its type to `Deserialize` method in the `EiffelEvent` class.
+*Hence, as a developer experience and a standard implementation, we chose to initialize them, as they are objects and their internal properties have their attribute validation checks as specified by the Eiffel protocol. Also to avoid enforcing users to initialize unneeded objects, as the SDK is a kind of protocol abstraction. Finally, as a maintainability perspective, to eliminate bugs born by missing some validation for future updates or the Eiffel protocol stepping, in case if it selectively initializes the property that may be not applicable for Required validation.*
+
+```c#
+/// <inheritdoc/>
+public override EiffelActivityTriggeredData Data { get; init; } = new();
+   
+/// <inheritdoc/>
+public override EiffelActivityTriggeredMeta Meta { get; init; } = new();
+   
+/// <inheritdoc/>
+public override EiffelActivityTriggeredLinks Links { get; init; } = new();
+```
+
+5.  The event should implement `FromJson` method to pass its type to `Deserialize` method in the `EiffelEvent` class.
 
 
 ```c#
@@ -29,10 +43,6 @@ public override IEiffelEvent FromJson(string json)
 
 
 ```c#
- [Required]
- public override EiffelActivityTriggeredData Data { get; init; }
-
- //or
  [Required(AllowEmptyStrings = false)]
  public string Name { get; init; }
 ```

--- a/src/EiffelEvents.Net/Common/EiffelShouldSerializeAttribute.cs
+++ b/src/EiffelEvents.Net/Common/EiffelShouldSerializeAttribute.cs
@@ -16,17 +16,17 @@ using System;
 
 namespace EiffelEvents.Net.Common;
 /// <summary>
-/// Custom attribute used to mark property which should be serialized even if empty or null.
+/// Custom attribute used to mark collection property which should be serialized even if empty or null.
 /// </summary>
 [AttributeUsage(AttributeTargets.Property)]
-public class ShouldSerializeAttribute: Attribute
+public class EiffelShouldSerializeAttribute: Attribute
 {
     public bool Yes
     {
         get;
     }
 
-    public ShouldSerializeAttribute()
+    public EiffelShouldSerializeAttribute()
     {
         Yes = true;
     }

--- a/src/EiffelEvents.Net/Common/JsonHelper.cs
+++ b/src/EiffelEvents.Net/Common/JsonHelper.cs
@@ -78,18 +78,19 @@ namespace EiffelEvents.Net.Common
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {
             var property = base.CreateProperty(member, memberSerialization);
-
+            bool customShouldSerialize;
+            
             //Ignore Empty collection in serialization/deserialization
             if (property.PropertyType?.GetInterface(nameof(ICollection)) != null)
             {
-                // Only Serialize Collections when they have values.
+                customShouldSerialize = member.GetCustomAttribute<ShouldSerializeAttribute>()?.Yes ?? false;
+                // Only Serialize Collections when they have values or marked as ShouldSerialize.
                 property.ShouldSerialize =
                     instance =>
                         property.UnderlyingName != null &&
-                        (instance?.GetType().GetProperty(property.UnderlyingName,
-                                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)?
-                            .GetValue(instance) as ICollection)?
-                        .Count > 0;
+                        (customShouldSerialize ||
+                         (instance?.GetType().GetProperty(property.UnderlyingName,BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)?
+                             .GetValue(instance) as ICollection)?.Count > 0);
 
                 // CollectionValueProvider for ICollection types to be set by empty object when not provided in JSON.
                 property.ValueProvider = new CollectionValueProvider(property.ValueProvider, property.PropertyType);

--- a/src/EiffelEvents.Net/Common/JsonHelper.cs
+++ b/src/EiffelEvents.Net/Common/JsonHelper.cs
@@ -78,17 +78,17 @@ namespace EiffelEvents.Net.Common
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {
             var property = base.CreateProperty(member, memberSerialization);
-            bool customShouldSerialize;
+            bool eiffelShouldSerialize;
             
             //Ignore Empty collection in serialization/deserialization
             if (property.PropertyType?.GetInterface(nameof(ICollection)) != null)
             {
-                customShouldSerialize = member.GetCustomAttribute<ShouldSerializeAttribute>()?.Yes ?? false;
+                eiffelShouldSerialize = member.GetCustomAttribute<EiffelShouldSerializeAttribute>()?.Yes ?? false;
                 // Only Serialize Collections when they have values or marked as ShouldSerialize.
                 property.ShouldSerialize =
                     instance =>
                         property.UnderlyingName != null &&
-                        (customShouldSerialize ||
+                        (eiffelShouldSerialize ||
                          (instance?.GetType().GetProperty(property.UnderlyingName,BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)?
                              .GetValue(instance) as ICollection)?.Count > 0);
 

--- a/src/EiffelEvents.Net/Common/ShouldSerializeAttribute.cs
+++ b/src/EiffelEvents.Net/Common/ShouldSerializeAttribute.cs
@@ -1,0 +1,34 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+
+namespace EiffelEvents.Net.Common;
+/// <summary>
+/// Custom attribute used to mark property which should be serialized even if empty or null.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public class ShouldSerializeAttribute: Attribute
+{
+    public bool Yes
+    {
+        get;
+    }
+
+    public ShouldSerializeAttribute()
+    {
+        Yes = true;
+    }
+
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityTriggeredEvent/EiffelActivityTriggeredEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityTriggeredEvent/EiffelActivityTriggeredEvent.cs
@@ -22,13 +22,13 @@ namespace EiffelEvents.Net.Events.Edition_Lyon
         : EiffelEvent<EiffelActivityTriggeredData, EiffelActivityTriggeredMeta, EiffelActivityTriggeredLinks>
     {
         /// <inheritdoc/>
-        public override EiffelActivityTriggeredData Data { get; init; }
+        public override EiffelActivityTriggeredData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelActivityTriggeredMeta Meta { get; init; }
+        public override EiffelActivityTriggeredMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelActivityTriggeredLinks Links { get; init; }
+        public override EiffelActivityTriggeredLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelActivityCanceledEvent/EiffelActivityCanceledEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelActivityCanceledEvent/EiffelActivityCanceledEvent.cs
@@ -30,13 +30,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         : EiffelEvent<EiffelActivityCanceledData, EiffelActivityCanceledMeta, EiffelActivityCanceledLinks>
     {
         /// <inheritdoc/>
-        public override EiffelActivityCanceledData Data { get; init; }
+        public override EiffelActivityCanceledData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelActivityCanceledMeta Meta { get; init; }
+        public override EiffelActivityCanceledMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelActivityCanceledLinks Links { get; init; }
+        public override EiffelActivityCanceledLinks Links { get; init; } = new();
 
         public override IEiffelEvent FromJson(string json)
         {

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelActivityFinishedEvent/EiffelActivityFinishedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelActivityFinishedEvent/EiffelActivityFinishedEvent.cs
@@ -29,13 +29,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         : EiffelEvent<EiffelActivityFinishedData,EiffelActivityFinishedMeta,EiffelActivityFinishedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelActivityFinishedData Data { get; init; }
+        public override EiffelActivityFinishedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelActivityFinishedMeta Meta { get; init; }
+        public override EiffelActivityFinishedMeta Meta { get; init; } = new();
         
         /// <inheritdoc/>
-        public override EiffelActivityFinishedLinks Links { get; init; }
+        public override EiffelActivityFinishedLinks Links { get; init; } = new();
         
         public override IEiffelEvent FromJson(string json)
         {

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelActivityStartedEvent/EiffelActivityStartedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelActivityStartedEvent/EiffelActivityStartedEvent.cs
@@ -31,13 +31,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         #region Props
 
         /// <inheritdoc/>
-        public override EiffelActivityStartedData Data { get; init; }
+        public override EiffelActivityStartedData Data { get; init; } = new();
         
         /// <inheritdoc/>
-        public override EiffelActivityStartedMeta Meta { get; init; }
+        public override EiffelActivityStartedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelActivityStartedLinks Links { get; init; }
+        public override EiffelActivityStartedLinks Links { get; init; } = new();
         #endregion
 
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelActivityTriggeredEvent/EiffelActivityTriggeredEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelActivityTriggeredEvent/EiffelActivityTriggeredEvent.cs
@@ -31,13 +31,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         #region Props
 
         /// <inheritdoc/>
-        public override EiffelActivityTriggeredData Data { get; init; }
+        public override EiffelActivityTriggeredData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelActivityTriggeredMeta Meta { get; init; }
+        public override EiffelActivityTriggeredMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelActivityTriggeredLinks Links { get; init; }
+        public override EiffelActivityTriggeredLinks Links { get; init; } = new();
 
         #endregion
 

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelAnnouncementPublishedEvent/EiffelAnnouncementPublishedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelAnnouncementPublishedEvent/EiffelAnnouncementPublishedEvent.cs
@@ -29,13 +29,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelAnnouncementPublishedData, EiffelAnnouncementPublishedMeta, EiffelAnnouncementPublishedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelAnnouncementPublishedData Data { get; init; }
+        public override EiffelAnnouncementPublishedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelAnnouncementPublishedMeta Meta { get; init; }
+        public override EiffelAnnouncementPublishedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelAnnouncementPublishedLinks Links { get; init; }
+        public override EiffelAnnouncementPublishedLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelArtifactCreatedEvent/EiffelArtifactCreatedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelArtifactCreatedEvent/EiffelArtifactCreatedEvent.cs
@@ -28,13 +28,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelArtifactCreatedData, EiffelArtifactCreatedMeta, EiffelArtifactCreatedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelArtifactCreatedData Data { get; init; }
+        public override EiffelArtifactCreatedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelArtifactCreatedMeta Meta { get; init; }
+        public override EiffelArtifactCreatedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelArtifactCreatedLinks Links { get; init; }
+        public override EiffelArtifactCreatedLinks Links { get; init; } = new();
 
         public override IEiffelEvent FromJson(string json)
         {

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelArtifactPublishedEvent/EiffelArtifactPublishedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelArtifactPublishedEvent/EiffelArtifactPublishedEvent.cs
@@ -28,13 +28,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelArtifactPublishedData, EiffelArtifactPublishedMeta, EiffelArtifactPublishedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelArtifactPublishedData Data { get; init; }
+        public override EiffelArtifactPublishedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelArtifactPublishedMeta Meta { get; init; }
+        public override EiffelArtifactPublishedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelArtifactPublishedLinks Links { get; init; }
+        public override EiffelArtifactPublishedLinks Links { get; init; } = new();
 
         public override IEiffelEvent FromJson(string json)
         {

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelArtifactReusedEvent/EiffelArtifactReusedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelArtifactReusedEvent/EiffelArtifactReusedEvent.cs
@@ -30,10 +30,10 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         public override EiffelArtifactReusedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelArtifactReusedMeta Meta { get; init; }
+        public override EiffelArtifactReusedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelArtifactReusedLinks Links { get; init; }
+        public override EiffelArtifactReusedLinks Links { get; init; } = new();
 
 
         /// <inheritdoc/>

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelCompositionDefinedEvent/EiffelCompositionDefinedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelCompositionDefinedEvent/EiffelCompositionDefinedEvent.cs
@@ -28,13 +28,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelCompositionDefinedData, EiffelCompositionDefinedMeta, EiffelCompositionDefinedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelCompositionDefinedData Data { get; init; }
+        public override EiffelCompositionDefinedData Data { get; init; } = new();
         
         /// <inheritdoc/>
-        public override EiffelCompositionDefinedMeta Meta { get; init; }
+        public override EiffelCompositionDefinedMeta Meta { get; init; } = new();
         
         /// <inheritdoc/>
-        public override EiffelCompositionDefinedLinks Links { get; init; }
+        public override EiffelCompositionDefinedLinks Links { get; init; } = new();
         
         public override IEiffelEvent FromJson(string json)
         {

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelConfidenceLevelModifiedEvent/EiffelConfidenceLevelModifiedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelConfidenceLevelModifiedEvent/EiffelConfidenceLevelModifiedEvent.cs
@@ -32,13 +32,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
             EiffelConfidenceLevelModifiedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelConfidenceLevelModifiedData Data { get; init; }
+        public override EiffelConfidenceLevelModifiedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelConfidenceLevelModifiedMeta Meta { get; init; }
+        public override EiffelConfidenceLevelModifiedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelConfidenceLevelModifiedLinks Links { get; init; }
+        public override EiffelConfidenceLevelModifiedLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelEnvironmentDefinedEvent/EiffelEnvironmentDefinedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelEnvironmentDefinedEvent/EiffelEnvironmentDefinedEvent.cs
@@ -32,13 +32,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
     {
         
         /// <inheritdoc/>
-        public override EiffelEnvironmentDefinedData Data { get; init; }= new();
+        public override EiffelEnvironmentDefinedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelEnvironmentDefinedMeta Meta { get; init; }
+        public override EiffelEnvironmentDefinedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelEnvironmentDefinedLinks Links { get; init; }
+        public override EiffelEnvironmentDefinedLinks Links { get; init; } = new();
 
         public override IEiffelEvent FromJson(string json)
         {

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelFlowContextDefinedEvent/EiffelFlowContextDefinedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelFlowContextDefinedEvent/EiffelFlowContextDefinedEvent.cs
@@ -32,13 +32,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelFlowContextDefinedData, EiffelFlowContextDefinedMeta, EiffelFlowContextDefinedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelFlowContextDefinedData Data { get; init; }
+        public override EiffelFlowContextDefinedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelFlowContextDefinedMeta Meta { get; init; }
+        public override EiffelFlowContextDefinedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelFlowContextDefinedLinks Links { get; init; }
+        public override EiffelFlowContextDefinedLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelIssueDefinedEvent/EiffelIssueDefinedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelIssueDefinedEvent/EiffelIssueDefinedEvent.cs
@@ -28,13 +28,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelIssueDefinedData, EiffelIssueDefinedMeta, EiffelIssueDefinedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelIssueDefinedData Data { get; init; }
+        public override EiffelIssueDefinedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelIssueDefinedMeta Meta { get; init; }
+        public override EiffelIssueDefinedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelIssueDefinedLinks Links { get; init; }
+        public override EiffelIssueDefinedLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelIssueVerifiedEvent/EiffelIssueVerifiedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelIssueVerifiedEvent/EiffelIssueVerifiedEvent.cs
@@ -32,10 +32,10 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         public override EiffelIssueVerifiedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelIssueVerifiedMeta Meta { get; init; }
+        public override EiffelIssueVerifiedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelIssueVerifiedLinks Links { get; init; }
+        public override EiffelIssueVerifiedLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelSourceChangeCreatedEvent/EiffelSourceChangeCreatedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelSourceChangeCreatedEvent/EiffelSourceChangeCreatedEvent.cs
@@ -30,13 +30,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelSourceChangeCreatedData, EiffelSourceChangeCreatedMeta, EiffelSourceChangeCreatedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelSourceChangeCreatedData Data { get; init; }
+        public override EiffelSourceChangeCreatedData Data { get; init; } = new();
         
         /// <inheritdoc/>
-        public override EiffelSourceChangeCreatedMeta Meta { get; init; }
+        public override EiffelSourceChangeCreatedMeta Meta { get; init; } = new();
         
         /// <inheritdoc/>
-        public override EiffelSourceChangeCreatedLinks Links { get; init; }
+        public override EiffelSourceChangeCreatedLinks Links { get; init; } = new();
         
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelSourceChangeSubmittedEvent/EiffelSourceChangeSubmittedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelSourceChangeSubmittedEvent/EiffelSourceChangeSubmittedEvent.cs
@@ -29,13 +29,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelSourceChangeSubmittedData, EiffelSourceChangeSubmittedMeta, EiffelSourceChangeSubmittedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelSourceChangeSubmittedData Data { get; init; }
+        public override EiffelSourceChangeSubmittedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelSourceChangeSubmittedMeta Meta { get; init; }
+        public override EiffelSourceChangeSubmittedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelSourceChangeSubmittedLinks Links { get; init; }
+        public override EiffelSourceChangeSubmittedLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestCaseCanceledEvent/EiffelTestCaseCanceledEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestCaseCanceledEvent/EiffelTestCaseCanceledEvent.cs
@@ -29,13 +29,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelTestCaseCanceledData, EiffelTestCaseCanceledMeta, EiffelTestCaseCanceledLinks>
     {
         /// <inheritdoc/>
-        public override EiffelTestCaseCanceledData Data { get; init; }
+        public override EiffelTestCaseCanceledData Data { get; init; } = new();
         
         /// <inheritdoc/>
-        public override EiffelTestCaseCanceledMeta Meta { get; init; }
+        public override EiffelTestCaseCanceledMeta Meta { get; init; } = new();
         
         /// <inheritdoc/>
-        public override EiffelTestCaseCanceledLinks Links { get; init; }
+        public override EiffelTestCaseCanceledLinks Links { get; init; } = new();
         public override IEiffelEvent FromJson(string json)
         {
             return Deserialize<EiffelTestCaseCanceledEvent>(json);

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestCaseFinishedEvent/EiffelTestCaseFinishedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestCaseFinishedEvent/EiffelTestCaseFinishedEvent.cs
@@ -27,13 +27,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelTestCaseFinishedData, EiffelTestCaseFinishedMeta, EiffelTestCaseFinishedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelTestCaseFinishedData Data { get; init; }
+        public override EiffelTestCaseFinishedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelTestCaseFinishedMeta Meta { get; init; }
+        public override EiffelTestCaseFinishedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelTestCaseFinishedLinks Links { get; init; }
+        public override EiffelTestCaseFinishedLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestCaseStartedEvent/EiffelTestCaseStartedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestCaseStartedEvent/EiffelTestCaseStartedEvent.cs
@@ -31,13 +31,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelTestCaseStartedData, EiffelTestCaseStartedMeta, EiffelTestCaseStartedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelTestCaseStartedData Data { get; init; }
+        public override EiffelTestCaseStartedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelTestCaseStartedMeta Meta { get; init; }
+        public override EiffelTestCaseStartedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelTestCaseStartedLinks Links { get; init; }
+        public override EiffelTestCaseStartedLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestCaseTriggeredEvent/EiffelTestCaseTriggeredEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestCaseTriggeredEvent/EiffelTestCaseTriggeredEvent.cs
@@ -30,13 +30,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelTestCaseTriggeredData, EiffelTestCaseTriggeredMeta, EiffelTestCaseTriggeredLinks>
     {
         /// <inheritdoc/>
-        public override EiffelTestCaseTriggeredData Data { get; init; }
+        public override EiffelTestCaseTriggeredData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelTestCaseTriggeredMeta Meta { get; init; }
+        public override EiffelTestCaseTriggeredMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelTestCaseTriggeredLinks Links { get; init; }
+        public override EiffelTestCaseTriggeredLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestExecutionRecipeCollectionCreatedEvent/EiffelTestExecutionRecipeCollectionCreatedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestExecutionRecipeCollectionCreatedEvent/EiffelTestExecutionRecipeCollectionCreatedEvent.cs
@@ -29,13 +29,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
             EiffelTestExecutionRecipeCollectionCreatedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelTestExecutionRecipeCollectionCreatedData Data { get; init; }
+        public override EiffelTestExecutionRecipeCollectionCreatedData Data { get; init; } = new();
         
         /// <inheritdoc/>
-        public override EiffelTestExecutionRecipeCollectionCreatedMeta Meta { get; init; }
+        public override EiffelTestExecutionRecipeCollectionCreatedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelTestExecutionRecipeCollectionCreatedLinks Links { get; init; }
+        public override EiffelTestExecutionRecipeCollectionCreatedLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestSuiteFinishedEvent/EiffelTestSuiteFinishedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestSuiteFinishedEvent/EiffelTestSuiteFinishedEvent.cs
@@ -29,13 +29,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelTestSuiteFinishedData, EiffelTestSuiteFinishedMeta, EiffelTestSuiteFinishedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelTestSuiteFinishedData Data { get; init; }
+        public override EiffelTestSuiteFinishedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelTestSuiteFinishedMeta Meta { get; init; }
+        public override EiffelTestSuiteFinishedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelTestSuiteFinishedLinks Links { get; init; }
+        public override EiffelTestSuiteFinishedLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestSuiteStartedEvent/EiffelTestSuiteStartedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestSuiteStartedEvent/EiffelTestSuiteStartedEvent.cs
@@ -33,13 +33,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelTestSuiteStartedData, EiffelTestSuiteStartedMeta, EiffelTestSuiteStartedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelTestSuiteStartedData Data { get; init; }
+        public override EiffelTestSuiteStartedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelTestSuiteStartedMeta Meta { get; init; }
+        public override EiffelTestSuiteStartedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelTestSuiteStartedLinks Links { get; init; }
+        public override EiffelTestSuiteStartedLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/Shared/EiffelEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/Shared/EiffelEvent.cs
@@ -63,6 +63,7 @@ namespace EiffelEvents.Net.Events.Edition_Paris.Shared
         public abstract TLinks Links { get; init; }
 
         [JsonProperty("links")]
+        [ShouldSerialize]
         internal virtual IEiffelSerializedLinkCollection SerializedLinks { get; init; } =
             new EiffelSerializedLinkCollection();
 

--- a/src/EiffelEvents.Net/Events/Edition-Paris/Shared/EiffelEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/Shared/EiffelEvent.cs
@@ -63,7 +63,7 @@ namespace EiffelEvents.Net.Events.Edition_Paris.Shared
         public abstract TLinks Links { get; init; }
 
         [JsonProperty("links")]
-        [ShouldSerialize]
+        [EiffelShouldSerialize]
         internal virtual IEiffelSerializedLinkCollection SerializedLinks { get; init; } =
             new EiffelSerializedLinkCollection();
 

--- a/tests/EiffelEvents.Net.Tests/Events/Edition-Lyon/EiffelActivityTriggeredEventTests.cs
+++ b/tests/EiffelEvents.Net.Tests/Events/Edition-Lyon/EiffelActivityTriggeredEventTests.cs
@@ -236,5 +236,19 @@ namespace EiffelEvents.Net.Tests.Events.Edition_Lyon
             //Assert
             actualSerializedEvent.Should().BeEquivalentTo(expected);
         }
+        
+        [Fact]
+        public void ToJson_Serialize_Empty_Links_Success()
+        {
+            //Arrange
+            var activityTriggeredEvent = _eventFixture.GetEventWithEmptyLinks();
+            var expected = _eventFixture.GetEventWithEmptyLinksSerialized();
+
+            //Act
+            var actualSerializedEvent = activityTriggeredEvent.ToJson();
+
+            //Assert
+            actualSerializedEvent.Should().BeEquivalentTo(expected);
+        }
     }
 }

--- a/tests/EiffelEvents.Net.Tests/Events/Edition-Paris/EiffelActivityTriggeredEventTests.cs
+++ b/tests/EiffelEvents.Net.Tests/Events/Edition-Paris/EiffelActivityTriggeredEventTests.cs
@@ -237,5 +237,19 @@ namespace EiffelEvents.Net.Tests.Events.Edition_Paris
             //Assert
             actualSerializedEvent.Should().BeEquivalentTo(expected);
         }
+        
+        [Fact]
+        public void ToJson_Serialize_Empty_Links_Success()
+        {
+            //Arrange
+            var activityTriggeredEvent = _eventFixture.GetEventWithEmptyLinks();
+            var expected = _eventFixture.GetEventWithEmptyLinksSerialized();
+
+            //Act
+            var actualSerializedEvent = activityTriggeredEvent.ToJson();
+
+            //Assert
+            actualSerializedEvent.Should().BeEquivalentTo(expected);
+        }
     }
 }

--- a/tests/EiffelEvents.Net.Tests/Events/Edition-Paris/EiffelFlowContextDefinedEventTests.cs
+++ b/tests/EiffelEvents.Net.Tests/Events/Edition-Paris/EiffelFlowContextDefinedEventTests.cs
@@ -48,7 +48,7 @@ namespace EiffelEvents.Net.Tests.Events.Edition_Paris
         public void Validate_MissingRequired_Failed()
         {
             //Arrange
-            var flowContextDefinedEvent = new EiffelFlowContextDefinedEvent();
+            var flowContextDefinedEvent = _eventFixture.GetMissedRequiredEvent();
 
             //Act
             var result = flowContextDefinedEvent.Validate();

--- a/tests/EiffelEvents.Net.Tests/Events/Edition-Paris/EiffelSourceChangeCreatedEventTests.cs
+++ b/tests/EiffelEvents.Net.Tests/Events/Edition-Paris/EiffelSourceChangeCreatedEventTests.cs
@@ -48,7 +48,7 @@ namespace EiffelEvents.Net.Tests.Events.Edition_Paris
         public void Validate_MissingRequired_Failed()
         {
             //Arrange
-            var sourceChangeCreatedEvent = new EiffelSourceChangeCreatedEvent();
+            var sourceChangeCreatedEvent = _eventFixture.GetMissedRequiredEvent();
 
             //Act
             var result = sourceChangeCreatedEvent.Validate();

--- a/tests/EiffelEvents.Net.Tests/Events/Edition-Paris/EiffelSourceChangeSubmittedEventTests.cs
+++ b/tests/EiffelEvents.Net.Tests/Events/Edition-Paris/EiffelSourceChangeSubmittedEventTests.cs
@@ -48,7 +48,7 @@ namespace EiffelEvents.Net.Tests.Events.Edition_Paris
         public void Validate_MissingRequired_Failed()
         {
             //Arrange
-            var sourceChangeSubmittedEvent = new EiffelSourceChangeSubmittedEvent();
+            var sourceChangeSubmittedEvent = _eventFixture.GetMissedRequiredEvent();
 
             //Act
             var result = sourceChangeSubmittedEvent.Validate();

--- a/tests/EiffelEvents.Net.Tests/TestData/Edition-Lyon/EiffelActivityTriggeredEventFixture.cs
+++ b/tests/EiffelEvents.Net.Tests/TestData/Edition-Lyon/EiffelActivityTriggeredEventFixture.cs
@@ -630,6 +630,99 @@ namespace EiffelEvents.Net.Tests.TestData.Edition_Lyon
         }
 
         #endregion
+        
+        #region Valid Event empty Links (ICollection types)
+
+        /// <summary>
+        /// Get a valid instance of EiffelActivityTriggeredEvent with empty Links.
+        /// </summary>
+        /// <returns></returns>
+        public EiffelActivityTriggeredEvent GetEventWithEmptyLinks()
+        {
+             return new EiffelActivityTriggeredEvent()
+            {
+                Data = new()
+                {
+                    Name = "My activity",
+                    Categories = new() { "category 1", "category 2" },
+                    Triggers = new()
+                    {
+                        new()
+                        {
+                            Type = EiffelDataTriggerType.SOURCE_CHANGE,
+                            Description = "Description"
+                        }
+                    },
+                    ExecutionType = EiffelDataExecutionType.AUTOMATED,
+                    CustomData = new()
+                    {
+                        { "key1", "test" },
+                        { "key2", 1 }
+                    }
+                },
+                Meta = new()
+                {
+                    Id = "91d0c7da-8d90-4033-8685-a035853aeea1",
+                    Time = 1637001247776,
+                    Tags = new() { "activity_block" },
+                    Security = new()
+                    {
+                        AuthorIdentity = "Flower"
+                    }
+                },
+                Links = new()
+                
+            };
+        }
+
+        public string GetEventWithEmptyLinksSerialized()
+        {
+            var json = JObject.Parse(@"{
+                              'data': {
+                                        'name': 'My activity',
+                                        'categories': [
+                                        'category 1',
+                                        'category 2'
+                                            ],
+                                        'triggers': [
+                                        {
+                                            'type': 'SOURCE_CHANGE',
+                                            'description': 'Description'
+                                        }
+                                        ],
+                                        'executionType': 'AUTOMATED',
+                                         'customData': [
+                                            {
+                                                'key': 'key1',
+                                                'value': 'test'
+                                            },
+                                            {
+                                                'key': 'key2',
+                                                'value': 1
+                                            }
+                                            ]
+                                    },
+                                    'meta': {
+                                        'type': 'EiffelActivityTriggeredEvent',
+                                        'version': '4.1.0',
+                                        'tags': [
+                                        'activity_block'
+                                            ],
+                                        'source': {
+                                                    'serializer': 'pkg:nuget/EiffelEvents.Net@1.0.0.0'
+                                         },
+                                        'security': {
+                                            'authorIdentity': 'Flower'
+                                        },
+                                        'id': '91d0c7da-8d90-4033-8685-a035853aeea1',
+                                        'time': 1637001247776
+                                    },
+                                'links': [ ]
+                            }");
+            return json.ToString();
+        }
+
+        #endregion
 
         #region Not Valid Guids
 

--- a/tests/EiffelEvents.Net.Tests/TestData/Edition-Paris/EiffelActivityTriggeredEventFixture.cs
+++ b/tests/EiffelEvents.Net.Tests/TestData/Edition-Paris/EiffelActivityTriggeredEventFixture.cs
@@ -508,6 +508,71 @@ namespace EiffelEvents.Net.Tests.TestData.Edition_Paris
         }
 
         #endregion
+        
+        #region Valid Event empty Links (ICollection types)
+
+        /// <summary>
+        /// Get a valid instance of EiffelActivityTriggeredEvent with empty Links.
+        /// </summary>
+        /// <returns></returns>
+        public EiffelActivityTriggeredEvent GetEventWithEmptyLinks()
+        {
+            return new EiffelActivityTriggeredEvent()
+            {
+                Data = new()
+                {
+                    Name = "My activity",
+                    Categories = new() { "category 1", "category 2" },
+                    Triggers = new(),
+                    ExecutionType = EiffelDataExecutionType.AUTOMATED,
+                    CustomData = new()
+                },
+                Meta = new()
+                {
+                    Id = "91d0c7da-8d90-4033-8685-a035853aeea1",
+                    Time = 1637001247776,
+                    Tags = new() { "activity_block" },
+                    Security = new()
+                    {
+                        AuthorIdentity = "Flower"
+                    }
+                },
+                Links = new()
+            };
+        }
+
+        public string GetEventWithEmptyLinksSerialized()
+        {
+            var json = JObject.Parse(@"{
+                              'data': {
+                                        'name': 'My activity',
+                                        'categories': [
+                                        'category 1',
+                                        'category 2'
+                                            ],
+                                        'executionType': 'AUTOMATED'
+                                    },
+                                    'meta': {
+                                        'type': 'EiffelActivityTriggeredEvent',
+                                        'version': '4.0.0',
+                                        'tags': [
+                                        'activity_block'
+                                            ],
+                                        'source': {
+                                                    'serializer': 'pkg:nuget/EiffelEvents.Net@1.0.0.0'
+                                         },
+                                        'security': {
+                                            'authorIdentity': 'Flower'
+                                        },
+                                        'id': '91d0c7da-8d90-4033-8685-a035853aeea1',
+                                        'time': 1637001247776
+                                    },
+                                'links': [ ]
+                            }");
+            return json.ToString();
+        }
+
+        #endregion
 
         #region Not Valid Guids
 

--- a/tests/EiffelEvents.Net.Tests/TestData/Edition-Paris/EiffelFlowContextDefinedEventFixture.cs
+++ b/tests/EiffelEvents.Net.Tests/TestData/Edition-Paris/EiffelFlowContextDefinedEventFixture.cs
@@ -60,5 +60,19 @@ namespace EiffelEvents.Net.Tests.TestData.Edition_Paris
                 }
             };
         }
+        
+        /// <summary>
+        /// Get a invalid instance of EiffelFlowContextDefinedEvent.
+        /// </summary>
+        /// <returns></returns>
+        public EiffelFlowContextDefinedEvent GetMissedRequiredEvent()
+        {
+            return new EiffelFlowContextDefinedEvent
+            {
+                Data = null,
+                Meta = null,
+                Links = null
+            };
+        }
     }
 }

--- a/tests/EiffelEvents.Net.Tests/TestData/Edition-Paris/EiffelSourceChangeCreatedEventFixture.cs
+++ b/tests/EiffelEvents.Net.Tests/TestData/Edition-Paris/EiffelSourceChangeCreatedEventFixture.cs
@@ -78,5 +78,19 @@ namespace EiffelEvents.Net.Tests.TestData.Edition_Paris
                 }
             };
         }
+        
+        /// <summary>
+        /// Get a invalid instance of EiffelSourceChangeCreatedEvent.
+        /// </summary>
+        /// <returns></returns>
+        public EiffelSourceChangeCreatedEvent GetMissedRequiredEvent()
+        {
+            return new EiffelSourceChangeCreatedEvent
+            {
+                Data = null,
+                Meta = null,
+                Links = null
+            };
+        }
     }
 }

--- a/tests/EiffelEvents.Net.Tests/TestData/Edition-Paris/EiffelSourceChangeSubmittedEventFixture.cs
+++ b/tests/EiffelEvents.Net.Tests/TestData/Edition-Paris/EiffelSourceChangeSubmittedEventFixture.cs
@@ -74,5 +74,19 @@ namespace EiffelEvents.Net.Tests.TestData.Edition_Paris
                 }
             };
         }
+        
+        /// <summary>
+        /// Get a invalid instance of EiffelSourceChangeSubmittedEvent.
+        /// </summary>
+        /// <returns></returns>
+        public EiffelSourceChangeSubmittedEvent GetMissedRequiredEvent()
+        {
+            return new EiffelSourceChangeSubmittedEvent
+            {
+                Data = null,
+                Meta = null,
+                Links = null
+            };
+        }
     }
 }


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
This pull request resolves #20 to serialize empty Links property to [] in the published event, as the default behavior of the SDK to ignore empty collection types (like Lists) in serialization, but Links are excluded as they are required by events schema definition.

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->

- Add EiffelShouldSerializeAttribute to selectively serialize empty attributes, as the default is to ignore empty collection in serialization.
- Apply ShouldSerializeAttribute on SerializedLinks (links in serialized object).
- Add Serialize empty links unit tests to Edition-Paris.
- Add Serialize empty links unit tests to Edition-Lyon.
- Initialize Data, Meta, and Links properties with `new()` so main event parts be always serialized. Although, they are required by the protocol schemas for all events, sometimes are not applicable to some events that have no Data or Links required such as `EiffelArtifactReusedEvent` that has no required Data (internal properties),  `EiffelActivityTriggeredEvent,` and `EiffelAnnouncementPublishedEvent` that has no required Links  (internal properties).
Hence,  we chose to initialize them, for the following reasons:
1. To avoid enforcing users to initialize unneeded objects, as a developer experience and considering the SDK is a kind of protocol abstraction.
2. These properties (Meta, Data, Links) are objects and their internal properties have their attribute validation checks as specified by the Eiffel protocol. 
3.  From a maintainability perspective, to provide standard implementation, to eliminate bugs born by missing some validation for future updates or the Eiffel protocol stepping, in case if it selectively initializes the property that may be not applicable for Required validation.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
N/A
### Benefits
<!-- What benefits will be realized by the change? -->

- All main event parts are represented in the event message, as a kind of contract even if no info is provided for them.
- Enhance user (developer) experience.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
N/A
### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Ahmed Abou Elfotouh ahmed.fotouh@live.com
