### PR TITLE
Lyon add eiffel activity started

### DIFF
--- a/docs/docfx_project/articles/implement-event.md
+++ b/docs/docfx_project/articles/implement-event.md
@@ -1,6 +1,6 @@
 # Implement Events Checklist
 
-This checklist to follow when implementing events. 
+This checklist is to follow when implementing events. 
 
 1. 
    Create directory for event under `Events/<edition namespace directory>`, for instance **Events / Edition-Paris / EiffelActivityTriggeredEvent**.
@@ -14,8 +14,22 @@ public record EiffelActivityTriggeredEvent
 ```
 
 3. Each Data, Links, and Meta properties has its own class, such as `<EventName>Data`, `<EventName>Links`, and `<EventName>Meta` respectively, e.g `EiffelActivityTriggeredData`, as long as the event itself.
+4. Initialize Data, Meta, and Links properties with `new()`. Although, they are required by the protocol schemas for all events, sometimes are not applicable to some events that have no Data or Links required such as `EiffelArtifactReusedEvent` that has no required Data (internal properties) required,  `EiffelActivityTriggeredEvent,` and `EiffelAnnouncementPublishedEvent` that has no required Links  (internal properties).
 
-4. The event should implement `FromJson` method to pass its type to `Deserialize` method in the `EiffelEvent` class.
+*Hence, as a developer experience and a standard implementation, we chose to initialize them, as they are objects and their internal properties have their attribute validation checks as specified by the Eiffel protocol. Also to avoid enforcing users to initialize unneeded objects, as the SDK is a kind of protocol abstraction. Finally, as a maintainability perspective, to eliminate bugs born by missing some validation for future updates or the Eiffel protocol stepping, in case if it selectively initializes the property that may be not applicable for Required validation.*
+
+```c#
+/// <inheritdoc/>
+public override EiffelActivityTriggeredData Data { get; init; } = new();
+   
+/// <inheritdoc/>
+public override EiffelActivityTriggeredMeta Meta { get; init; } = new();
+   
+/// <inheritdoc/>
+public override EiffelActivityTriggeredLinks Links { get; init; } = new();
+```
+
+5.  The event should implement `FromJson` method to pass its type to `Deserialize` method in the `EiffelEvent` class.
 
 
 ```c#
@@ -29,10 +43,6 @@ public override IEiffelEvent FromJson(string json)
 
 
 ```c#
- [Required]
- public override EiffelActivityTriggeredData Data { get; init; }
-
- //or
  [Required(AllowEmptyStrings = false)]
  public string Name { get; init; }
 ```

--- a/examples/EiffelClient.PublisherOne/Models/Edition-Lyon/ActivityCanceled.cs
+++ b/examples/EiffelClient.PublisherOne/Models/Edition-Lyon/ActivityCanceled.cs
@@ -1,0 +1,46 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+using EiffelEvents.Net.Events.Edition_Lyon;
+
+namespace EiffelClient.PublisherOne.Models.Edition_Lyon
+{
+    public class ActivityCanceled
+    {
+        public static EiffelActivityCanceledEvent GetEvent()
+        {
+            return new EiffelActivityCanceledEvent
+            {
+                Data = new ()
+                {
+                    Reason = "Made irrelevant by newly scheduled execution"
+                },
+                Meta = new ()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Security = new ()
+                    {
+                        AuthorIdentity = "Flower"
+                    }
+                },
+                Links = new ()
+                {
+                    ActivityExecution = new(Guid.NewGuid().ToString(),"com.domain.xyz"),
+                    Cause = new () { new(Guid.NewGuid().ToString(),"com.domain.xyz") }
+                }
+            };
+        }
+    }
+}

--- a/examples/EiffelClient.PublisherOne/Models/Edition-Lyon/ActivityStarted.cs
+++ b/examples/EiffelClient.PublisherOne/Models/Edition-Lyon/ActivityStarted.cs
@@ -1,0 +1,93 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+using EiffelEvents.Net.Events.Edition_Lyon;
+
+
+namespace EiffelClient.PublisherOne.Models.Edition_Lyon
+{
+    public class ActivityStarted
+    {
+        public static EiffelActivityStartedEvent GetEvent()
+        {
+            return new EiffelActivityStartedEvent()
+            {
+                Data = new()
+                {
+                    ExecutionUri = "https://my.jenkins.host/myJob/43",
+                    LiveLogs = new()
+                    {
+                        new ()
+                        {
+                            Name = "My build log",
+                            MediaType = "text/plain",
+                            Uri = "file:///tmp/logs/data.log",
+                            Tags = new(){"build"}
+                        }
+                    },
+                    CustomData = new()
+                    {
+                        { "key1", "test" },
+                        { "key2", 1 }
+                    }
+                },
+                Meta = new()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Time = 1637001247776,
+                    Tags = new() { "activity_block" },
+                    Security = new()
+                    {
+                        AuthorIdentity = "Flower"
+                    }
+                },
+                Links = new()
+                {
+                    Cause = new()
+                    {
+                        new()
+                        {
+                            Target = Guid.NewGuid().ToString(),
+                            DomainId = "test-domain-id"
+                        },
+                        new()
+                        {
+                            Target = Guid.NewGuid().ToString()
+                        }
+                    },
+                    Context = new()
+                    {
+                        Target = Guid.NewGuid().ToString(),
+                        DomainId = "test-domain-id"
+                    },
+                    FlowContext = new()
+                    {
+                        new()
+                        {
+                            Target = Guid.NewGuid().ToString(),
+                            DomainId = "test-domain-id"
+                        }
+                    },
+                    ActivityExecution = new(Guid.NewGuid().ToString(), "test-domain-id"),
+                    PreviousActivityExecution = new()
+                    {
+                        DomainId = "test-domain-id",
+                        Target = Guid.NewGuid().ToString()
+                    }
+                }
+            };
+        }
+    }
+}

--- a/examples/EiffelClient.PublisherOne/Models/Edition-Lyon/Client.cs
+++ b/examples/EiffelClient.PublisherOne/Models/Edition-Lyon/Client.cs
@@ -36,7 +36,7 @@ namespace EiffelClient.PublisherOne.Models.Edition_Lyon
                 nameof(EiffelActivityTriggeredEvent) => ActivityTriggered.GetEvent() as T,
 
                 // nameof(EiffelActivityStartedEvent) => ActivityStarted.GetEvent() as T,
-                // nameof(EiffelActivityCanceledEvent) => ActivityCanceled.GetEvent() as T,
+                nameof(EiffelActivityCanceledEvent) => ActivityCanceled.GetEvent() as T,
                 // nameof(EiffelActivityFinishedEvent) => ActivityFinished.GetEvent() as T,
                 // nameof(EiffelArtifactCreatedEvent) => ArtifactCreated.GetEvent() as T,
                 // nameof(EiffelArtifactReusedEvent) => ArtifactReused.GetEvent() as T,

--- a/examples/EiffelClient.PublisherOne/Models/Edition-Lyon/Client.cs
+++ b/examples/EiffelClient.PublisherOne/Models/Edition-Lyon/Client.cs
@@ -35,7 +35,7 @@ namespace EiffelClient.PublisherOne.Models.Edition_Lyon
             {
                 nameof(EiffelActivityTriggeredEvent) => ActivityTriggered.GetEvent() as T,
 
-                // nameof(EiffelActivityStartedEvent) => ActivityStarted.GetEvent() as T,
+                nameof(EiffelActivityStartedEvent) => ActivityStarted.GetEvent() as T,
                 nameof(EiffelActivityCanceledEvent) => ActivityCanceled.GetEvent() as T,
                 // nameof(EiffelActivityFinishedEvent) => ActivityFinished.GetEvent() as T,
                 // nameof(EiffelArtifactCreatedEvent) => ArtifactCreated.GetEvent() as T,

--- a/examples/EiffelClient.PublisherOne/Program.cs
+++ b/examples/EiffelClient.PublisherOne/Program.cs
@@ -26,8 +26,8 @@ namespace EiffelClient.PublisherOne
             Console.WriteLine("Started !!");
 
             // Create a raw event
-            var eiffelEvent = TryClient.GetEvent<EiffelActivityTriggeredEvent>();
-            var signedEvent = eiffelEvent?.Sign<EiffelActivityTriggeredEvent>();
+            var eiffelEvent = TryClient.GetEvent<EiffelActivityCanceledEvent>();
+            var signedEvent = eiffelEvent?.Sign<EiffelActivityCanceledEvent>();
             /*for (int i = 0; i < 10000; i++)
            {*/
             var result = TryClient.Eiffelclient.Publish(signedEvent);

--- a/examples/EiffelClient.PublisherOne/Program.cs
+++ b/examples/EiffelClient.PublisherOne/Program.cs
@@ -26,8 +26,8 @@ namespace EiffelClient.PublisherOne
             Console.WriteLine("Started !!");
 
             // Create a raw event
-            var eiffelEvent = TryClient.GetEvent<EiffelActivityCanceledEvent>();
-            var signedEvent = eiffelEvent?.Sign<EiffelActivityCanceledEvent>();
+            var eiffelEvent = TryClient.GetEvent<EiffelActivityStartedEvent>();
+            var signedEvent = eiffelEvent?.Sign<EiffelActivityStartedEvent>();
             /*for (int i = 0; i < 10000; i++)
            {*/
             var result = TryClient.Eiffelclient.Publish(signedEvent);

--- a/examples/EiffelClient.SubscriberOne/Program.cs
+++ b/examples/EiffelClient.SubscriberOne/Program.cs
@@ -41,8 +41,8 @@ namespace EiffelClient.SubscriberOne
             Console.WriteLine("Started ....");
 
             // Subscribe to events
-            _subscriptionId = _client.Subscribe<EiffelActivityCanceledEvent>(_queueIdentifier, GeneralHandleEvent);
-            Console.WriteLine($"Subscription done to event {nameof(EiffelActivityCanceledEvent)} !");
+            _subscriptionId = _client.Subscribe<EiffelActivityStartedEvent>(_queueIdentifier, GeneralHandleEvent);
+            Console.WriteLine($"Subscription done to event {nameof(EiffelActivityStartedEvent)} !");
 
             while (true)
             {

--- a/examples/EiffelClient.SubscriberOne/Program.cs
+++ b/examples/EiffelClient.SubscriberOne/Program.cs
@@ -30,7 +30,7 @@ namespace EiffelClient.SubscriberOne
         private static IEiffelClient _client;
         private static RabbitMqConfig _rabbitMqConfig;
         private static string _subscriptionId = string.Empty;
-        private static string _queueIdentifier= "autor";
+        private static string _queueIdentifier = "autor";
 
         public static void Main(string[] args)
         {
@@ -41,8 +41,8 @@ namespace EiffelClient.SubscriberOne
             Console.WriteLine("Started ....");
 
             // Subscribe to events
-            _subscriptionId = _client.Subscribe<EiffelActivityTriggeredEvent>(_queueIdentifier, GeneralHandleEvent);
-            Console.WriteLine($"Subscription done to event {nameof(EiffelActivityTriggeredEvent)} !");
+            _subscriptionId = _client.Subscribe<EiffelActivityCanceledEvent>(_queueIdentifier, GeneralHandleEvent);
+            Console.WriteLine($"Subscription done to event {nameof(EiffelActivityCanceledEvent)} !");
 
             while (true)
             {

--- a/examples/EiffelClient.SubscriberTwo/Program.cs
+++ b/examples/EiffelClient.SubscriberTwo/Program.cs
@@ -38,8 +38,8 @@ namespace EiffelClient.SubscriberTwo
             Console.WriteLine("Started ....");
 
             // Subscribe to events
-            _subscriptionId = _client.Subscribe<EiffelActivityTriggeredEvent>(_queueIdentifier, GeneralHandleEvent);
-            Console.WriteLine($"Subscription done to event {nameof(EiffelActivityTriggeredEvent)} !");
+            _subscriptionId = _client.Subscribe<EiffelActivityCanceledEvent>(_queueIdentifier, GeneralHandleEvent);
+            Console.WriteLine($"Subscription done to event {nameof(EiffelActivityCanceledEvent)} !");
 
             while (true)
             {

--- a/examples/EiffelClient.SubscriberTwo/Program.cs
+++ b/examples/EiffelClient.SubscriberTwo/Program.cs
@@ -38,8 +38,8 @@ namespace EiffelClient.SubscriberTwo
             Console.WriteLine("Started ....");
 
             // Subscribe to events
-            _subscriptionId = _client.Subscribe<EiffelActivityCanceledEvent>(_queueIdentifier, GeneralHandleEvent);
-            Console.WriteLine($"Subscription done to event {nameof(EiffelActivityCanceledEvent)} !");
+            _subscriptionId = _client.Subscribe<EiffelActivityStartedEvent>(_queueIdentifier, GeneralHandleEvent);
+            Console.WriteLine($"Subscription done to event {nameof(EiffelActivityStartedEvent)} !");
 
             while (true)
             {

--- a/src/EiffelEvents.Net/Common/EiffelShouldSerializeAttribute.cs
+++ b/src/EiffelEvents.Net/Common/EiffelShouldSerializeAttribute.cs
@@ -16,17 +16,17 @@ using System;
 
 namespace EiffelEvents.Net.Common;
 /// <summary>
-/// Custom attribute used to mark property which should be serialized even if empty or null.
+/// Custom attribute used to mark collection property which should be serialized even if empty or null.
 /// </summary>
 [AttributeUsage(AttributeTargets.Property)]
-public class ShouldSerializeAttribute: Attribute
+public class EiffelShouldSerializeAttribute: Attribute
 {
     public bool Yes
     {
         get;
     }
 
-    public ShouldSerializeAttribute()
+    public EiffelShouldSerializeAttribute()
     {
         Yes = true;
     }

--- a/src/EiffelEvents.Net/Common/JsonHelper.cs
+++ b/src/EiffelEvents.Net/Common/JsonHelper.cs
@@ -78,18 +78,19 @@ namespace EiffelEvents.Net.Common
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {
             var property = base.CreateProperty(member, memberSerialization);
-
+            bool customShouldSerialize;
+            
             //Ignore Empty collection in serialization/deserialization
             if (property.PropertyType?.GetInterface(nameof(ICollection)) != null)
             {
-                // Only Serialize Collections when they have values.
+                customShouldSerialize = member.GetCustomAttribute<ShouldSerializeAttribute>()?.Yes ?? false;
+                // Only Serialize Collections when they have values or marked as ShouldSerialize.
                 property.ShouldSerialize =
                     instance =>
                         property.UnderlyingName != null &&
-                        (instance?.GetType().GetProperty(property.UnderlyingName,
-                                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)?
-                            .GetValue(instance) as ICollection)?
-                        .Count > 0;
+                        (customShouldSerialize ||
+                         (instance?.GetType().GetProperty(property.UnderlyingName,BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)?
+                             .GetValue(instance) as ICollection)?.Count > 0);
 
                 // CollectionValueProvider for ICollection types to be set by empty object when not provided in JSON.
                 property.ValueProvider = new CollectionValueProvider(property.ValueProvider, property.PropertyType);

--- a/src/EiffelEvents.Net/Common/JsonHelper.cs
+++ b/src/EiffelEvents.Net/Common/JsonHelper.cs
@@ -78,17 +78,17 @@ namespace EiffelEvents.Net.Common
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {
             var property = base.CreateProperty(member, memberSerialization);
-            bool customShouldSerialize;
+            bool eiffelShouldSerialize;
             
             //Ignore Empty collection in serialization/deserialization
             if (property.PropertyType?.GetInterface(nameof(ICollection)) != null)
             {
-                customShouldSerialize = member.GetCustomAttribute<ShouldSerializeAttribute>()?.Yes ?? false;
+                eiffelShouldSerialize = member.GetCustomAttribute<EiffelShouldSerializeAttribute>()?.Yes ?? false;
                 // Only Serialize Collections when they have values or marked as ShouldSerialize.
                 property.ShouldSerialize =
                     instance =>
                         property.UnderlyingName != null &&
-                        (customShouldSerialize ||
+                        (eiffelShouldSerialize ||
                          (instance?.GetType().GetProperty(property.UnderlyingName,BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)?
                              .GetValue(instance) as ICollection)?.Count > 0);
 

--- a/src/EiffelEvents.Net/Common/ShouldSerializeAttribute.cs
+++ b/src/EiffelEvents.Net/Common/ShouldSerializeAttribute.cs
@@ -1,0 +1,34 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+
+namespace EiffelEvents.Net.Common;
+/// <summary>
+/// Custom attribute used to mark property which should be serialized even if empty or null.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public class ShouldSerializeAttribute: Attribute
+{
+    public bool Yes
+    {
+        get;
+    }
+
+    public ShouldSerializeAttribute()
+    {
+        Yes = true;
+    }
+
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityCanceledEvent/EiffelActivityCanceledData.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityCanceledEvent/EiffelActivityCanceledData.cs
@@ -1,0 +1,18 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon
+{
+    public record EiffelActivityCanceledData : Edition_Paris.EiffelActivityCanceledData;
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityCanceledEvent/EiffelActivityCanceledEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityCanceledEvent/EiffelActivityCanceledEvent.cs
@@ -12,35 +12,36 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-using System.ComponentModel.DataAnnotations;
+
 using EiffelEvents.Net.Events.Core;
 using EiffelEvents.Net.Events.Edition_Lyon.Shared;
 
 namespace EiffelEvents.Net.Events.Edition_Lyon
 {
     /// <summary>
-    /// Announces that an activity has been triggered.
-    /// <a href="https://github.com/eiffel-community/eiffel/blob/edition-lyon/eiffel-vocabulary/EiffelActivityTriggeredEvent.md">
-    /// EiffelActivityTriggeredEvent
+    /// The EiffelActivityCanceledEvent signals that a previously triggered activity execution
+    /// has been canceled before it has started
+    /// <a href="https://github.com/eiffel-community/eiffel/blob/edition-lyon/eiffel-vocabulary/EiffelActivityCanceledEvent.md">
+    /// EiffelActivityCanceledEvent
     /// </a>
     /// for details.
     /// </summary>
-    public record EiffelActivityTriggeredEvent
-        : EiffelEvent<EiffelActivityTriggeredData, EiffelActivityTriggeredMeta, EiffelActivityTriggeredLinks>
+    public record EiffelActivityCanceledEvent
+        : EiffelEvent<EiffelActivityCanceledData, EiffelActivityCanceledMeta, EiffelActivityCanceledLinks>
     {
         /// <inheritdoc/>
-        public override EiffelActivityTriggeredData Data { get; init; }
+        public override EiffelActivityCanceledData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelActivityTriggeredMeta Meta { get; init; }
+        public override EiffelActivityCanceledMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelActivityTriggeredLinks Links { get; init; }
+        public override EiffelActivityCanceledLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)
         {
-            return Deserialize<EiffelActivityTriggeredEvent>(json);
+            return Deserialize<EiffelActivityCanceledEvent>(json);
         }
     }
 }

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityCanceledEvent/EiffelActivityCanceledLinks.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityCanceledEvent/EiffelActivityCanceledLinks.cs
@@ -1,0 +1,34 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System.ComponentModel.DataAnnotations;
+using EiffelEvents.Net.Events.Edition_Lyon.Shared;
+using EiffelEvents.Net.Events.Edition_Lyon.Shared.Links;
+using EiffelEvents.Net.Validation;
+using Newtonsoft.Json;
+
+namespace EiffelEvents.Net.Events.Edition_Lyon
+{
+    [JsonArray]
+    public record EiffelActivityCanceledLinks : EiffelSharedLinks
+    {
+        /// <summary>
+        /// Declares the activity execution that was canceled.
+        /// Legal targets: EiffelActivityTriggeredEvent
+        /// </summary>
+        [Required]
+        [NestedObject]
+        public EiffelActivityExecutionLink ActivityExecution { get; init; }
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityCanceledEvent/EiffelActivityCanceledMeta.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityCanceledEvent/EiffelActivityCanceledMeta.cs
@@ -1,0 +1,24 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using EiffelEvents.Net.Events.Edition_Lyon.Shared;
+
+namespace EiffelEvents.Net.Events.Edition_Lyon
+{
+    public record EiffelActivityCanceledMeta : EiffelSharedMeta
+    {
+        public override string Type { get; init; } = nameof(EiffelActivityCanceledEvent);
+        public override string Version { get; init; } = "3.1.0";
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityStartedEvent/EiffelActivityStartedData.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityStartedEvent/EiffelActivityStartedData.cs
@@ -1,0 +1,36 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System.Collections.Generic;
+using EiffelEvents.Net.Events.Core.Data;
+using EiffelEvents.Net.Events.Edition_Lyon.Shared.Data;
+using EiffelEvents.Net.Validation;
+
+namespace EiffelEvents.Net.Events.Edition_Lyon
+{
+    public record EiffelActivityStartedData : EiffelData
+    {
+        /// <summary>
+        /// Any URI at which further information about the execution may be found;
+        /// a typical use case is to link a CI server job execution page.
+        /// </summary>
+        public string ExecutionUri { get; init; }
+
+        /// <summary>
+        /// An array of live log files available during execution
+        /// </summary>
+        [NestedList]
+        public List<EiffelLiveLog> LiveLogs { get; init; }
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityStartedEvent/EiffelActivityStartedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityStartedEvent/EiffelActivityStartedEvent.cs
@@ -1,0 +1,39 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System.ComponentModel.DataAnnotations;
+using EiffelEvents.Net.Events.Core;
+using EiffelEvents.Net.Events.Edition_Lyon.Shared;
+
+namespace EiffelEvents.Net.Events.Edition_Lyon
+{
+    public record EiffelActivityStartedEvent
+        : EiffelEvent<EiffelActivityStartedData, EiffelActivityStartedMeta, EiffelActivityStartedLinks>
+    {
+        /// <inheritdoc/>
+        public override EiffelActivityStartedData Data { get; init; } = new();
+
+        /// <inheritdoc/>
+        public override EiffelActivityStartedMeta Meta { get; init; } = new();
+
+        /// <inheritdoc/>
+        public override EiffelActivityStartedLinks Links { get; init; } = new();
+
+        /// <inheritdoc/>
+        public override IEiffelEvent FromJson(string json)
+        {
+            return Deserialize<EiffelActivityStartedEvent>(json);
+        }
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityStartedEvent/EiffelActivityStartedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityStartedEvent/EiffelActivityStartedEvent.cs
@@ -12,7 +12,6 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-using System.ComponentModel.DataAnnotations;
 using EiffelEvents.Net.Events.Core;
 using EiffelEvents.Net.Events.Edition_Lyon.Shared;
 

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityStartedEvent/EiffelActivityStartedLinks.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityStartedEvent/EiffelActivityStartedLinks.cs
@@ -1,0 +1,25 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using EiffelEvents.Net.Events.Edition_Lyon.Shared;
+using Newtonsoft.Json;
+
+namespace EiffelEvents.Net.Events.Edition_Lyon
+{
+    [JsonArray]
+    public record EiffelActivityStartedLinks : EiffelSharedLinks
+    {
+        
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityStartedEvent/EiffelActivityStartedLinks.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityStartedEvent/EiffelActivityStartedLinks.cs
@@ -12,7 +12,11 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using EiffelEvents.Net.Events.Edition_Lyon.Shared;
+using EiffelEvents.Net.Events.Edition_Lyon.Shared.Links;
+using EiffelEvents.Net.Validation;
 using Newtonsoft.Json;
 
 namespace EiffelEvents.Net.Events.Edition_Lyon
@@ -20,6 +24,20 @@ namespace EiffelEvents.Net.Events.Edition_Lyon
     [JsonArray]
     public record EiffelActivityStartedLinks : EiffelSharedLinks
     {
+        /// <summary>
+        /// Declares the activity execution that was canceled.
+        /// In other words, <see cref="EiffelActivityTriggeredEvent"/> acts as a handle for the activity execution.
+        /// This differs from <see cref="EiffelContextLink"/>.
+        /// </summary>
+        [Required]
+        [NestedObject]
+        public EiffelActivityExecutionLink ActivityExecution { get; init; }
         
+        /// <summary>
+        /// Identifies the latest previous execution of the activity.
+        /// </summary>
+        [NestedObject]
+        public EiffelPreviousActivityExecutionLink PreviousActivityExecution { get; init; }
+
     }
 }

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityStartedEvent/EiffelActivityStartedMeta.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityStartedEvent/EiffelActivityStartedMeta.cs
@@ -1,0 +1,24 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using EiffelEvents.Net.Events.Edition_Lyon.Shared;
+
+namespace EiffelEvents.Net.Events.Edition_Lyon
+{
+    public record EiffelActivityStartedMeta : EiffelSharedMeta
+    {
+        public override string Type { get; init; } = nameof(EiffelActivityStartedEvent);
+        public override string Version { get; init; } = "4.2.0";
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityTriggeredEvent/EiffelActivityTriggeredEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityTriggeredEvent/EiffelActivityTriggeredEvent.cs
@@ -29,13 +29,13 @@ namespace EiffelEvents.Net.Events.Edition_Lyon
         : EiffelEvent<EiffelActivityTriggeredData, EiffelActivityTriggeredMeta, EiffelActivityTriggeredLinks>
     {
         /// <inheritdoc/>
-        public override EiffelActivityTriggeredData Data { get; init; }
+        public override EiffelActivityTriggeredData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelActivityTriggeredMeta Meta { get; init; }
+        public override EiffelActivityTriggeredMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelActivityTriggeredLinks Links { get; init; }
+        public override EiffelActivityTriggeredLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Data/EiffelLiveLog.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Data/EiffelLiveLog.cs
@@ -1,0 +1,33 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System.Collections.Generic;
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Data
+{
+    public class EiffelLiveLog : Edition_Paris.Shared.Data.EiffelLiveLog
+    {
+        /// <summary>
+        /// The <a href="https://en.wikipedia.org/wiki/Media_type">media type</a> of the URI's payload.
+        /// Can be used to differentiate between various representations of the same log, e.g. text/html for human consumption and text/plain or application/json for the machine-readable form.
+        /// </summary>
+        public string MediaType { get; init; }
+
+        /// <summary>
+        /// Arbitrary tags and keywords that describe this log.
+        /// </summary>
+
+        public List<string> Tags { get; init; }
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelActivityExecutionLinks.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelActivityExecutionLinks.cs
@@ -1,0 +1,30 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    public record EiffelActivityExecutionLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "ACTIVITY_EXECUTION";
+
+        public EiffelActivityExecutionLink()
+        {
+        }
+
+        public EiffelActivityExecutionLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelActivityExecutionLinks.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelActivityExecutionLinks.cs
@@ -14,6 +14,11 @@
 
 namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
 {
+    /// <summary>
+    /// Declares the activity execution that was canceled.
+    /// In other words, <see cref="EiffelActivityTriggeredEvent"/> acts as a handle for the activity execution.
+    /// This differs from <see cref="EiffelContextLink"/>.
+    /// </summary>
     public record EiffelActivityExecutionLink : EiffelLink
     {
         /// <inheritdoc/>

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelArtifact Link.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelArtifact Link.cs
@@ -1,0 +1,34 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    /// <summary>
+    /// Identifies the artifact that was published.
+    /// </summary>
+    public record EiffelArtifactLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "ARTIFACT";
+
+        public EiffelArtifactLink()
+        {
+        }
+
+        public EiffelArtifactLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelBaseLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelBaseLink.cs
@@ -1,0 +1,34 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    /// <summary>
+    /// Identifies the base revision of the created source change.
+    /// </summary>
+    public record EiffelBaseLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "BASE";
+
+        public EiffelBaseLink()
+        {
+        }
+
+        public EiffelBaseLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelCauseLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelCauseLink.cs
@@ -14,6 +14,11 @@
 
 namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
 {
+    /// <summary>
+    /// Identifies a cause of the event occurring. SHOULD not be used in conjunction with <see cref="EiffelContextLink"/>:
+    /// individual events providing EiffelCauseLink within a larger context gives rise to ambiguity.
+    /// It is instead recommended to let the root event of the context declare  <see cref="EiffelContextLink"/>.  
+    /// </summary>
     public record EiffelCauseLink : EiffelLink
     {
         /// <inheritdoc/>

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelChangeLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelChangeLink.cs
@@ -1,0 +1,34 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    /// <summary>
+    /// Identifies the change that was submitted.
+    /// </summary>
+    public record EiffelChangeLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "CHANGE";
+
+        public EiffelChangeLink()
+        {
+        }
+
+        public EiffelChangeLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelCompositionLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelCompositionLink.cs
@@ -1,0 +1,34 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    /// <summary>
+    /// Identifies the composition from which this artifact was built.
+    /// </summary>
+    public record EiffelCompositionLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "COMPOSITION";
+
+        public EiffelCompositionLink()
+        {
+        }
+
+        public EiffelCompositionLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelContextLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelContextLink.cs
@@ -14,6 +14,9 @@
 
 namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
 {
+    /// <summary>
+    /// Identifies the activity or test suite of which this event constitutes a part.
+    /// </summary>
     public record EiffelContextLink : EiffelLink
     {
         /// <inheritdoc/>

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelDeresolvedIssueLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelDeresolvedIssueLink.cs
@@ -1,0 +1,35 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    /// <summary>
+    /// Identifies an issue which was previously resolved, but that this SCC claims it has made changes to warrant removing the resolved status.
+    /// For example, if an issue "Feature X" was resolved, but this SCC removed the implementation that led to "Feature X" being resolved, that issue should no longer be considered resolved.
+    /// </summary>
+    public record EiffelDeresolvedIssueLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "DERESOLVED_ISSUE";
+
+        public EiffelDeresolvedIssueLink()
+        {
+        }
+
+        public EiffelDeresolvedIssueLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelElementLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelElementLink.cs
@@ -1,0 +1,34 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    /// <summary>
+    /// Identifies an element and/or sub-composition of a composition.
+    /// </summary>
+    public record EiffelElementLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "ELEMENT";
+
+        public EiffelElementLink()
+        {
+        }
+
+        public EiffelElementLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelEnvironmentLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelEnvironmentLink.cs
@@ -1,0 +1,34 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    /// <summary>
+    /// Identifies the environment in which this artifact was built.
+    /// </summary>
+    public record EiffelEnvironmentLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "ENVIRONMENT";
+
+        public EiffelEnvironmentLink()
+        {
+        }
+
+        public EiffelEnvironmentLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelFailedIssueLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelFailedIssueLink.cs
@@ -1,0 +1,34 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    /// <summary>
+    /// Identifies an issue that has failed verification.
+    /// </summary>
+    public record EiffelFailedIssueLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "FAILED_ISSUE";
+
+        public EiffelFailedIssueLink()
+        {
+        }
+
+        public EiffelFailedIssueLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelFlowContextLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelFlowContextLink.cs
@@ -14,6 +14,10 @@
 
 namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
 {
+    /// <summary>
+    /// Identifies the flow context of the event: which is the continuous integration and delivery flow in which
+    /// this occurred e.g. which product, project, track or version this is applicable to.
+    /// </summary>
     public record EiffelFlowContextLink : EiffelLink
     {
         /// <inheritdoc/>

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelInconclusiveIssueLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelInconclusiveIssueLink.cs
@@ -1,0 +1,34 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    /// <summary>
+    /// Identifies an issue for which this verification was inconclusive.
+    /// </summary>
+    public record EiffelInconclusiveIssueLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "INCONCLUSIVE_ISSUE";
+
+        public EiffelInconclusiveIssueLink()
+        {
+        }
+
+        public EiffelInconclusiveIssueLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelIutLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelIutLink.cs
@@ -1,0 +1,34 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    /// <summary>
+    /// Identifies the Item Under Test; in other words, the entity for which the issue has been verified.
+    /// </summary>
+    public record EiffelIutLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "IUT";
+
+        public EiffelIutLink()
+        {
+        }
+
+        public EiffelIutLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelModifiedAnnouncementLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelModifiedAnnouncementLink.cs
@@ -1,0 +1,36 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+
+    /// <summary>
+    /// Identifies an announcement of which this event represents an update or modification, if any.
+    /// Example usage is to declare the end to a previously announced situation.
+    /// </summary>
+    public record EiffelModifiedAnnouncementLink: EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "MODIFIED_ANNOUNCEMENT";
+
+        public EiffelModifiedAnnouncementLink()
+        {
+        }
+
+        public EiffelModifiedAnnouncementLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelPartiallyResolvedIssueLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelPartiallyResolvedIssueLink.cs
@@ -1,0 +1,36 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    /// <summary>
+    /// Identifies an issue that this event partially resolves.
+    /// That is, this SCC introduces some change that has advanced an issue towards a resolved state,
+    /// but not completely resolved.
+    /// </summary>
+    public record EiffelPartiallyResolvedIssueLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "PARTIALLY_RESOLVED_ISSUE";
+
+        public EiffelPartiallyResolvedIssueLink()
+        {
+        }
+
+        public EiffelPartiallyResolvedIssueLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelPreviousActivityExecutionLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelPreviousActivityExecutionLink.cs
@@ -1,0 +1,36 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+
+    /// <summary>
+    /// Identifies the latest previous execution of the activity.
+    /// </summary>
+    public record EiffelPreviousActivityExecutionLink: EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "PREVIOUS_ACTIVITY_EXECUTION";
+
+        public EiffelPreviousActivityExecutionLink()
+        {
+        }
+
+        public EiffelPreviousActivityExecutionLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelPreviousVersionLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelPreviousVersionLink.cs
@@ -1,0 +1,34 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    /// <summary>
+    /// Identifies a latest previous version (there may be more than one in case of merges) of the artifact the event represents.
+    /// </summary>
+    public record EiffelPreviousVersionLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "PREVIOUS_VERSION";
+
+        public EiffelPreviousVersionLink()
+        {
+        }
+
+        public EiffelPreviousVersionLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelResolvedIssueLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelResolvedIssueLink.cs
@@ -1,0 +1,36 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    /// <summary>
+    /// Identifies an issue that this SCC is claiming it has done enough to resolve. This is not an authoritative resolution only a claim.
+    /// The issue may or may not change status as a consequence this, e.g. through a successful verification <seealso cref="EiffelIssueVirifiedEvent"/>
+    /// or a manual update on the issue tracker.
+    /// </summary>
+    public record EiffelResolvedIssueLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "RESOLVED_ISSUE";
+
+        public EiffelResolvedIssueLink()
+        {
+        }
+
+        public EiffelResolvedIssueLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelReusedArtifactLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelReusedArtifactLink.cs
@@ -1,0 +1,35 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    /// <summary>
+    /// This link identifies the <see cref="EiffelArtifactCreatedEvent"> that is reused for the composition identified
+    /// by <see cref="EiffelCompositionLink"/> in other words, the artifact that is not rebuilt for a that composition.
+    /// </summary>
+    public record EiffelReusedArtifactLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "REUSED_ARTIFACT";
+
+        public EiffelReusedArtifactLink()
+        {
+        }
+
+        public EiffelReusedArtifactLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelRuntimeEnvironmentLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelRuntimeEnvironmentLink.cs
@@ -1,0 +1,36 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    /// <summary>
+    /// Identifies a description of a runtime environment within which an activity has taken place. The target event could
+    /// e.g. identify a Docker image, a JVM distribution archive, or a composition of operating system packages that were installed on the host system.
+    /// This link type has the same purpose as the `data.image` member but allows richer and less ambiguous descriptions.
+    /// </summary>
+    public record EiffelRuntimeEnvironmentLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "RUNTIME_ENVIRONMENT";
+
+        public EiffelRuntimeEnvironmentLink()
+        {
+        }
+
+        public EiffelRuntimeEnvironmentLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelSubConfidenceLevelLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelSubConfidenceLevelLink.cs
@@ -1,0 +1,37 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    /// <summary>
+    /// Used in events summarizing multiple confidence levels.
+    /// Example use case: the confidence level "allTestsOk" summarizes the confidence levels "unitTestsOk, "scenarioTestsOk"
+    /// and "deploymentTestsOk", and consequently links to them via EiffelSubConfidenceLevelLink.
+    /// This is intended for purely descriptive, rather than prescriptive, use.
+    /// </summary>
+    public record EiffelSubConfidenceLevelLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "SUB_CONFIDENCE_LEVEL";
+
+        public EiffelSubConfidenceLevelLink()
+        {
+        }
+
+        public EiffelSubConfidenceLevelLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelSubjectLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelSubjectLink.cs
@@ -1,0 +1,34 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    /// <summary>
+    /// Identifies a subject of the confidence level; in other words, what the confidence level applies to.
+    /// </summary>
+    public record EiffelSubjectLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "SUBJECT";
+
+        public EiffelSubjectLink()
+        {
+        }
+
+        public EiffelSubjectLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelSuccessfulIssueLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelSuccessfulIssueLink.cs
@@ -1,0 +1,34 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    /// <summary>
+    /// Identifies an issue that has been successfully verified.
+    /// </summary>
+    public record EiffelSuccessfulIssueLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "SUCCESSFUL_ISSUE";
+
+        public EiffelSuccessfulIssueLink()
+        {
+        }
+
+        public EiffelSuccessfulIssueLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelTercLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelTercLink.cs
@@ -1,0 +1,35 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    /// <summary>
+    /// This link signifies that the test suite represented by this event groups all test case executions resulting from
+    /// the <see cref="EiffelTestExecutionRecipeCollectionCreatedEvent"/>
+    /// </summary>
+    public record EiffelTercLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "TERC";
+
+        public EiffelTercLink()
+        {
+        }
+
+        public EiffelTercLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelTestCaseExecutionLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelTestCaseExecutionLink.cs
@@ -1,0 +1,36 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    /// <summary>
+    /// Identifies the relevant test case execution. In other words, <see cref="EiffelTestCaseTriggeredEvent"> acts as a handle for
+    /// a particular test case execution.  This differs from <see cref="EiffelContextLink"/>.
+    /// In EiffelTestCaseExecutionLink the source carries information pertaining to the target (i.e. the test case execution started, finished or was canceled).
+    /// </summary>
+    public record EiffelTestCaseExecutionLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "TEST_CASE_EXECUTION";
+
+        public EiffelTestCaseExecutionLink()
+        {
+        }
+
+        public EiffelTestCaseExecutionLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelTestSuiteExecutionLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelTestSuiteExecutionLink.cs
@@ -1,0 +1,34 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    /// <summary>
+    /// Identifies the relevant test suite execution. <see cref="EiffelTestSuiteStartedEvent"/> acts as a handle for a particular test suite execution.
+    /// </summary>
+    public record EiffelTestSuiteExecutionLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "TEST_SUITE_EXECUTION";
+
+        public EiffelTestSuiteExecutionLink()
+        {
+        }
+
+        public EiffelTestSuiteExecutionLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelVerificationBasisLink.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/Shared/Links/EiffelVerificationBasisLink.cs
@@ -1,0 +1,34 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon.Shared.Links
+{
+    /// <summary>
+    /// Used to declare the basis on which the verification statement(s) of this event have been issued.
+    /// </summary>
+    public record EiffelVerificationBasisLink : EiffelLink
+    {
+        /// <inheritdoc/>
+        public override string Type => "VERIFICATION_BASIS";
+
+        public EiffelVerificationBasisLink()
+        {
+        }
+
+        public EiffelVerificationBasisLink(string target, string domainId = "") : base(target, domainId)
+        {
+        }
+
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelActivityCanceledEvent/EiffelActivityCanceledEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelActivityCanceledEvent/EiffelActivityCanceledEvent.cs
@@ -30,13 +30,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         : EiffelEvent<EiffelActivityCanceledData, EiffelActivityCanceledMeta, EiffelActivityCanceledLinks>
     {
         /// <inheritdoc/>
-        public override EiffelActivityCanceledData Data { get; init; }
+        public override EiffelActivityCanceledData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelActivityCanceledMeta Meta { get; init; }
+        public override EiffelActivityCanceledMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelActivityCanceledLinks Links { get; init; }
+        public override EiffelActivityCanceledLinks Links { get; init; } = new();
 
         public override IEiffelEvent FromJson(string json)
         {

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelActivityFinishedEvent/EiffelActivityFinishedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelActivityFinishedEvent/EiffelActivityFinishedEvent.cs
@@ -29,13 +29,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         : EiffelEvent<EiffelActivityFinishedData,EiffelActivityFinishedMeta,EiffelActivityFinishedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelActivityFinishedData Data { get; init; }
+        public override EiffelActivityFinishedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelActivityFinishedMeta Meta { get; init; }
+        public override EiffelActivityFinishedMeta Meta { get; init; } = new();
         
         /// <inheritdoc/>
-        public override EiffelActivityFinishedLinks Links { get; init; }
+        public override EiffelActivityFinishedLinks Links { get; init; } = new();
         
         public override IEiffelEvent FromJson(string json)
         {

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelActivityStartedEvent/EiffelActivityStartedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelActivityStartedEvent/EiffelActivityStartedEvent.cs
@@ -31,13 +31,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         #region Props
 
         /// <inheritdoc/>
-        public override EiffelActivityStartedData Data { get; init; }
+        public override EiffelActivityStartedData Data { get; init; } = new();
         
         /// <inheritdoc/>
-        public override EiffelActivityStartedMeta Meta { get; init; }
+        public override EiffelActivityStartedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelActivityStartedLinks Links { get; init; }
+        public override EiffelActivityStartedLinks Links { get; init; } = new();
         #endregion
 
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelActivityTriggeredEvent/EiffelActivityTriggeredEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelActivityTriggeredEvent/EiffelActivityTriggeredEvent.cs
@@ -31,13 +31,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         #region Props
 
         /// <inheritdoc/>
-        public override EiffelActivityTriggeredData Data { get; init; }
+        public override EiffelActivityTriggeredData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelActivityTriggeredMeta Meta { get; init; }
+        public override EiffelActivityTriggeredMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelActivityTriggeredLinks Links { get; init; }
+        public override EiffelActivityTriggeredLinks Links { get; init; } = new();
 
         #endregion
 

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelAnnouncementPublishedEvent/EiffelAnnouncementPublishedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelAnnouncementPublishedEvent/EiffelAnnouncementPublishedEvent.cs
@@ -29,13 +29,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelAnnouncementPublishedData, EiffelAnnouncementPublishedMeta, EiffelAnnouncementPublishedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelAnnouncementPublishedData Data { get; init; }
+        public override EiffelAnnouncementPublishedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelAnnouncementPublishedMeta Meta { get; init; }
+        public override EiffelAnnouncementPublishedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelAnnouncementPublishedLinks Links { get; init; }
+        public override EiffelAnnouncementPublishedLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelArtifactCreatedEvent/EiffelArtifactCreatedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelArtifactCreatedEvent/EiffelArtifactCreatedEvent.cs
@@ -28,13 +28,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelArtifactCreatedData, EiffelArtifactCreatedMeta, EiffelArtifactCreatedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelArtifactCreatedData Data { get; init; }
+        public override EiffelArtifactCreatedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelArtifactCreatedMeta Meta { get; init; }
+        public override EiffelArtifactCreatedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelArtifactCreatedLinks Links { get; init; }
+        public override EiffelArtifactCreatedLinks Links { get; init; } = new();
 
         public override IEiffelEvent FromJson(string json)
         {

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelArtifactPublishedEvent/EiffelArtifactPublishedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelArtifactPublishedEvent/EiffelArtifactPublishedEvent.cs
@@ -28,13 +28,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelArtifactPublishedData, EiffelArtifactPublishedMeta, EiffelArtifactPublishedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelArtifactPublishedData Data { get; init; }
+        public override EiffelArtifactPublishedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelArtifactPublishedMeta Meta { get; init; }
+        public override EiffelArtifactPublishedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelArtifactPublishedLinks Links { get; init; }
+        public override EiffelArtifactPublishedLinks Links { get; init; } = new();
 
         public override IEiffelEvent FromJson(string json)
         {

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelArtifactReusedEvent/EiffelArtifactReusedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelArtifactReusedEvent/EiffelArtifactReusedEvent.cs
@@ -30,10 +30,10 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         public override EiffelArtifactReusedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelArtifactReusedMeta Meta { get; init; }
+        public override EiffelArtifactReusedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelArtifactReusedLinks Links { get; init; }
+        public override EiffelArtifactReusedLinks Links { get; init; } = new();
 
 
         /// <inheritdoc/>

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelCompositionDefinedEvent/EiffelCompositionDefinedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelCompositionDefinedEvent/EiffelCompositionDefinedEvent.cs
@@ -28,13 +28,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelCompositionDefinedData, EiffelCompositionDefinedMeta, EiffelCompositionDefinedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelCompositionDefinedData Data { get; init; }
+        public override EiffelCompositionDefinedData Data { get; init; } = new();
         
         /// <inheritdoc/>
-        public override EiffelCompositionDefinedMeta Meta { get; init; }
+        public override EiffelCompositionDefinedMeta Meta { get; init; } = new();
         
         /// <inheritdoc/>
-        public override EiffelCompositionDefinedLinks Links { get; init; }
+        public override EiffelCompositionDefinedLinks Links { get; init; } = new();
         
         public override IEiffelEvent FromJson(string json)
         {

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelConfidenceLevelModifiedEvent/EiffelConfidenceLevelModifiedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelConfidenceLevelModifiedEvent/EiffelConfidenceLevelModifiedEvent.cs
@@ -32,13 +32,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
             EiffelConfidenceLevelModifiedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelConfidenceLevelModifiedData Data { get; init; }
+        public override EiffelConfidenceLevelModifiedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelConfidenceLevelModifiedMeta Meta { get; init; }
+        public override EiffelConfidenceLevelModifiedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelConfidenceLevelModifiedLinks Links { get; init; }
+        public override EiffelConfidenceLevelModifiedLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelEnvironmentDefinedEvent/EiffelEnvironmentDefinedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelEnvironmentDefinedEvent/EiffelEnvironmentDefinedEvent.cs
@@ -32,13 +32,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
     {
         
         /// <inheritdoc/>
-        public override EiffelEnvironmentDefinedData Data { get; init; }= new();
+        public override EiffelEnvironmentDefinedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelEnvironmentDefinedMeta Meta { get; init; }
+        public override EiffelEnvironmentDefinedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelEnvironmentDefinedLinks Links { get; init; }
+        public override EiffelEnvironmentDefinedLinks Links { get; init; } = new();
 
         public override IEiffelEvent FromJson(string json)
         {

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelFlowContextDefinedEvent/EiffelFlowContextDefinedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelFlowContextDefinedEvent/EiffelFlowContextDefinedEvent.cs
@@ -32,13 +32,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelFlowContextDefinedData, EiffelFlowContextDefinedMeta, EiffelFlowContextDefinedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelFlowContextDefinedData Data { get; init; }
+        public override EiffelFlowContextDefinedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelFlowContextDefinedMeta Meta { get; init; }
+        public override EiffelFlowContextDefinedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelFlowContextDefinedLinks Links { get; init; }
+        public override EiffelFlowContextDefinedLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelIssueDefinedEvent/EiffelIssueDefinedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelIssueDefinedEvent/EiffelIssueDefinedEvent.cs
@@ -28,13 +28,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelIssueDefinedData, EiffelIssueDefinedMeta, EiffelIssueDefinedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelIssueDefinedData Data { get; init; }
+        public override EiffelIssueDefinedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelIssueDefinedMeta Meta { get; init; }
+        public override EiffelIssueDefinedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelIssueDefinedLinks Links { get; init; }
+        public override EiffelIssueDefinedLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelIssueVerifiedEvent/EiffelIssueVerifiedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelIssueVerifiedEvent/EiffelIssueVerifiedEvent.cs
@@ -32,10 +32,10 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         public override EiffelIssueVerifiedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelIssueVerifiedMeta Meta { get; init; }
+        public override EiffelIssueVerifiedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelIssueVerifiedLinks Links { get; init; }
+        public override EiffelIssueVerifiedLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelSourceChangeCreatedEvent/EiffelSourceChangeCreatedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelSourceChangeCreatedEvent/EiffelSourceChangeCreatedEvent.cs
@@ -30,13 +30,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelSourceChangeCreatedData, EiffelSourceChangeCreatedMeta, EiffelSourceChangeCreatedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelSourceChangeCreatedData Data { get; init; }
+        public override EiffelSourceChangeCreatedData Data { get; init; } = new();
         
         /// <inheritdoc/>
-        public override EiffelSourceChangeCreatedMeta Meta { get; init; }
+        public override EiffelSourceChangeCreatedMeta Meta { get; init; } = new();
         
         /// <inheritdoc/>
-        public override EiffelSourceChangeCreatedLinks Links { get; init; }
+        public override EiffelSourceChangeCreatedLinks Links { get; init; } = new();
         
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelSourceChangeSubmittedEvent/EiffelSourceChangeSubmittedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelSourceChangeSubmittedEvent/EiffelSourceChangeSubmittedEvent.cs
@@ -29,13 +29,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelSourceChangeSubmittedData, EiffelSourceChangeSubmittedMeta, EiffelSourceChangeSubmittedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelSourceChangeSubmittedData Data { get; init; }
+        public override EiffelSourceChangeSubmittedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelSourceChangeSubmittedMeta Meta { get; init; }
+        public override EiffelSourceChangeSubmittedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelSourceChangeSubmittedLinks Links { get; init; }
+        public override EiffelSourceChangeSubmittedLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestCaseCanceledEvent/EiffelTestCaseCanceledEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestCaseCanceledEvent/EiffelTestCaseCanceledEvent.cs
@@ -29,13 +29,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelTestCaseCanceledData, EiffelTestCaseCanceledMeta, EiffelTestCaseCanceledLinks>
     {
         /// <inheritdoc/>
-        public override EiffelTestCaseCanceledData Data { get; init; }
+        public override EiffelTestCaseCanceledData Data { get; init; } = new();
         
         /// <inheritdoc/>
-        public override EiffelTestCaseCanceledMeta Meta { get; init; }
+        public override EiffelTestCaseCanceledMeta Meta { get; init; } = new();
         
         /// <inheritdoc/>
-        public override EiffelTestCaseCanceledLinks Links { get; init; }
+        public override EiffelTestCaseCanceledLinks Links { get; init; } = new();
         public override IEiffelEvent FromJson(string json)
         {
             return Deserialize<EiffelTestCaseCanceledEvent>(json);

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestCaseFinishedEvent/EiffelTestCaseFinishedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestCaseFinishedEvent/EiffelTestCaseFinishedEvent.cs
@@ -27,13 +27,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelTestCaseFinishedData, EiffelTestCaseFinishedMeta, EiffelTestCaseFinishedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelTestCaseFinishedData Data { get; init; }
+        public override EiffelTestCaseFinishedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelTestCaseFinishedMeta Meta { get; init; }
+        public override EiffelTestCaseFinishedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelTestCaseFinishedLinks Links { get; init; }
+        public override EiffelTestCaseFinishedLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestCaseStartedEvent/EiffelTestCaseStartedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestCaseStartedEvent/EiffelTestCaseStartedEvent.cs
@@ -31,13 +31,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelTestCaseStartedData, EiffelTestCaseStartedMeta, EiffelTestCaseStartedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelTestCaseStartedData Data { get; init; }
+        public override EiffelTestCaseStartedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelTestCaseStartedMeta Meta { get; init; }
+        public override EiffelTestCaseStartedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelTestCaseStartedLinks Links { get; init; }
+        public override EiffelTestCaseStartedLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestCaseTriggeredEvent/EiffelTestCaseTriggeredEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestCaseTriggeredEvent/EiffelTestCaseTriggeredEvent.cs
@@ -30,13 +30,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelTestCaseTriggeredData, EiffelTestCaseTriggeredMeta, EiffelTestCaseTriggeredLinks>
     {
         /// <inheritdoc/>
-        public override EiffelTestCaseTriggeredData Data { get; init; }
+        public override EiffelTestCaseTriggeredData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelTestCaseTriggeredMeta Meta { get; init; }
+        public override EiffelTestCaseTriggeredMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelTestCaseTriggeredLinks Links { get; init; }
+        public override EiffelTestCaseTriggeredLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestExecutionRecipeCollectionCreatedEvent/EiffelTestExecutionRecipeCollectionCreatedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestExecutionRecipeCollectionCreatedEvent/EiffelTestExecutionRecipeCollectionCreatedEvent.cs
@@ -29,13 +29,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
             EiffelTestExecutionRecipeCollectionCreatedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelTestExecutionRecipeCollectionCreatedData Data { get; init; }
+        public override EiffelTestExecutionRecipeCollectionCreatedData Data { get; init; } = new();
         
         /// <inheritdoc/>
-        public override EiffelTestExecutionRecipeCollectionCreatedMeta Meta { get; init; }
+        public override EiffelTestExecutionRecipeCollectionCreatedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelTestExecutionRecipeCollectionCreatedLinks Links { get; init; }
+        public override EiffelTestExecutionRecipeCollectionCreatedLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestSuiteFinishedEvent/EiffelTestSuiteFinishedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestSuiteFinishedEvent/EiffelTestSuiteFinishedEvent.cs
@@ -29,13 +29,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelTestSuiteFinishedData, EiffelTestSuiteFinishedMeta, EiffelTestSuiteFinishedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelTestSuiteFinishedData Data { get; init; }
+        public override EiffelTestSuiteFinishedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelTestSuiteFinishedMeta Meta { get; init; }
+        public override EiffelTestSuiteFinishedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelTestSuiteFinishedLinks Links { get; init; }
+        public override EiffelTestSuiteFinishedLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestSuiteStartedEvent/EiffelTestSuiteStartedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/EiffelTestSuiteStartedEvent/EiffelTestSuiteStartedEvent.cs
@@ -33,13 +33,13 @@ namespace EiffelEvents.Net.Events.Edition_Paris
         EiffelEvent<EiffelTestSuiteStartedData, EiffelTestSuiteStartedMeta, EiffelTestSuiteStartedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelTestSuiteStartedData Data { get; init; }
+        public override EiffelTestSuiteStartedData Data { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelTestSuiteStartedMeta Meta { get; init; }
+        public override EiffelTestSuiteStartedMeta Meta { get; init; } = new();
 
         /// <inheritdoc/>
-        public override EiffelTestSuiteStartedLinks Links { get; init; }
+        public override EiffelTestSuiteStartedLinks Links { get; init; } = new();
 
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)

--- a/src/EiffelEvents.Net/Events/Edition-Paris/Shared/EiffelEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/Shared/EiffelEvent.cs
@@ -63,6 +63,7 @@ namespace EiffelEvents.Net.Events.Edition_Paris.Shared
         public abstract TLinks Links { get; init; }
 
         [JsonProperty("links")]
+        [ShouldSerialize]
         internal virtual IEiffelSerializedLinkCollection SerializedLinks { get; init; } =
             new EiffelSerializedLinkCollection();
 

--- a/src/EiffelEvents.Net/Events/Edition-Paris/Shared/EiffelEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Paris/Shared/EiffelEvent.cs
@@ -63,7 +63,7 @@ namespace EiffelEvents.Net.Events.Edition_Paris.Shared
         public abstract TLinks Links { get; init; }
 
         [JsonProperty("links")]
-        [ShouldSerialize]
+        [EiffelShouldSerialize]
         internal virtual IEiffelSerializedLinkCollection SerializedLinks { get; init; } =
             new EiffelSerializedLinkCollection();
 

--- a/tests/EiffelEvents.Net.Tests/Events/Edition-Lyon/EiffelActivityCanceledEventTests.cs
+++ b/tests/EiffelEvents.Net.Tests/Events/Edition-Lyon/EiffelActivityCanceledEventTests.cs
@@ -1,0 +1,92 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+using EiffelEvents.Net.Events.Edition_Lyon;
+using EiffelEvents.Net.Tests.TestData.Edition_Lyon;
+using FluentAssertions;
+using FluentResults;
+using Xunit;
+
+namespace EiffelEvents.Net.Tests.Events.Edition_Lyon
+{
+    public class EiffelActivityCanceledEventTests : IClassFixture<EiffelActivityCanceledEventFixture>
+    {
+        private readonly EiffelActivityCanceledEventFixture _eventFixture;
+
+        public EiffelActivityCanceledEventTests(EiffelActivityCanceledEventFixture eventFixture)
+        {
+            _eventFixture = eventFixture;
+        }
+
+        [Fact]
+        public void Validate_CompleteAttributes_Success()
+        {
+            //Arrange
+            var activityTriggeredEvent = _eventFixture.GetValidCompleteEvent();
+
+            //Act
+            Result result = activityTriggeredEvent.Validate();
+
+            //Assert
+            result.IsSuccess.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_MissingRequired_Failed()
+        {
+            //Arrange
+            var activityTriggeredEvent = new EiffelActivityCanceledEvent();
+
+            //Act
+            var result = activityTriggeredEvent.Validate();
+
+            //Assert
+            result.IsSuccess.Should().BeFalse();
+        }
+
+        [Fact]
+        public void VerifySignature_ValidSignature_Success()
+        {
+            //Arrange
+            var activityTriggeredEvent = _eventFixture.GetValidCompleteEvent();
+
+            //Act
+            var activityTriggeredEventSigned = activityTriggeredEvent.Sign<EiffelActivityCanceledEvent>();
+
+            //Assert
+            activityTriggeredEventSigned.VerifySignature().Should().BeTrue();
+        }
+
+        [Fact]
+        public void VerifySignature_CorruptedObject_Failed()
+        {
+            //Arrange
+            var activityTriggeredEvent = _eventFixture.GetValidCompleteEvent();
+
+            //Act
+            var activityTriggeredEventSigned = activityTriggeredEvent.Sign<EiffelActivityCanceledEvent>();
+            activityTriggeredEventSigned = activityTriggeredEventSigned with
+            {
+                Meta = activityTriggeredEventSigned.Meta with
+                {
+                    Id = Guid.NewGuid().ToString()
+                }
+            };
+
+            //Assert
+            activityTriggeredEventSigned.VerifySignature().Should().BeFalse();
+        }
+    }
+}

--- a/tests/EiffelEvents.Net.Tests/Events/Edition-Lyon/EiffelActivityStartedEventTests.cs
+++ b/tests/EiffelEvents.Net.Tests/Events/Edition-Lyon/EiffelActivityStartedEventTests.cs
@@ -1,0 +1,92 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+using EiffelEvents.Net.Events.Edition_Lyon;
+using EiffelEvents.Net.Tests.TestData.Edition_Lyon;
+using FluentAssertions;
+using FluentResults;
+using Xunit;
+
+namespace EiffelEvents.Net.Tests.Events.Edition_Lyon
+{
+    public class EiffelActivityStartedEventTests : IClassFixture<EiffelActivityStartedEventFixture>
+    {
+        private readonly EiffelActivityStartedEventFixture _eventFixture;
+
+        public EiffelActivityStartedEventTests(EiffelActivityStartedEventFixture eventFixture)
+        {
+            _eventFixture = eventFixture;
+        }
+
+        [Fact]
+        public void Validate_CompleteAttributes_Success()
+        {
+            //Arrange
+            var activityStartedEvent = _eventFixture.GetValidCompleteEvent();
+
+            //Act
+            Result result = activityStartedEvent.Validate();
+
+            //Assert
+            result.IsSuccess.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_MissingRequired_Failed()
+        {
+            //Arrange
+            var activityStartedEvent = new EiffelActivityStartedEvent();
+
+            //Act
+            var result = activityStartedEvent.Validate();
+
+            //Assert
+            result.IsSuccess.Should().BeFalse();
+        }
+
+        [Fact]
+        public void VerifySignature_ValidSignature_Success()
+        {
+            //Arrange
+            var activityStartedEvent = _eventFixture.GetValidCompleteEvent();
+
+            //Act
+            var activityStartedEventSigned = activityStartedEvent.Sign<EiffelActivityStartedEvent>();
+
+            //Assert
+            activityStartedEventSigned.VerifySignature().Should().BeTrue();
+        }
+
+        [Fact]
+        public void VerifySignature_CorruptedObject_Failed()
+        {
+            //Arrange
+            var activityStartedEvent = _eventFixture.GetValidCompleteEvent();
+
+            //Act
+            var activityStartedEventSigned = activityStartedEvent.Sign<EiffelActivityStartedEvent>();
+            activityStartedEventSigned = activityStartedEventSigned with
+            {
+                Meta = activityStartedEventSigned.Meta with
+                {
+                    Id = Guid.NewGuid().ToString()
+                }
+            };
+
+            //Assert
+            activityStartedEventSigned.VerifySignature().Should().BeFalse();
+        }
+    }
+}

--- a/tests/EiffelEvents.Net.Tests/Events/Edition-Lyon/EiffelActivityTriggeredEventTests.cs
+++ b/tests/EiffelEvents.Net.Tests/Events/Edition-Lyon/EiffelActivityTriggeredEventTests.cs
@@ -236,5 +236,19 @@ namespace EiffelEvents.Net.Tests.Events.Edition_Lyon
             //Assert
             actualSerializedEvent.Should().BeEquivalentTo(expected);
         }
+        
+        [Fact]
+        public void ToJson_Serialize_Empty_Links_Success()
+        {
+            //Arrange
+            var activityTriggeredEvent = _eventFixture.GetEventWithEmptyLinks();
+            var expected = _eventFixture.GetEventWithEmptyLinksSerialized();
+
+            //Act
+            var actualSerializedEvent = activityTriggeredEvent.ToJson();
+
+            //Assert
+            actualSerializedEvent.Should().BeEquivalentTo(expected);
+        }
     }
 }

--- a/tests/EiffelEvents.Net.Tests/Events/Edition-Paris/EiffelActivityTriggeredEventTests.cs
+++ b/tests/EiffelEvents.Net.Tests/Events/Edition-Paris/EiffelActivityTriggeredEventTests.cs
@@ -237,5 +237,19 @@ namespace EiffelEvents.Net.Tests.Events.Edition_Paris
             //Assert
             actualSerializedEvent.Should().BeEquivalentTo(expected);
         }
+        
+        [Fact]
+        public void ToJson_Serialize_Empty_Links_Success()
+        {
+            //Arrange
+            var activityTriggeredEvent = _eventFixture.GetEventWithEmptyLinks();
+            var expected = _eventFixture.GetEventWithEmptyLinksSerialized();
+
+            //Act
+            var actualSerializedEvent = activityTriggeredEvent.ToJson();
+
+            //Assert
+            actualSerializedEvent.Should().BeEquivalentTo(expected);
+        }
     }
 }

--- a/tests/EiffelEvents.Net.Tests/Events/Edition-Paris/EiffelFlowContextDefinedEventTests.cs
+++ b/tests/EiffelEvents.Net.Tests/Events/Edition-Paris/EiffelFlowContextDefinedEventTests.cs
@@ -48,7 +48,7 @@ namespace EiffelEvents.Net.Tests.Events.Edition_Paris
         public void Validate_MissingRequired_Failed()
         {
             //Arrange
-            var flowContextDefinedEvent = new EiffelFlowContextDefinedEvent();
+            var flowContextDefinedEvent = _eventFixture.GetMissedRequiredEvent();
 
             //Act
             var result = flowContextDefinedEvent.Validate();

--- a/tests/EiffelEvents.Net.Tests/Events/Edition-Paris/EiffelSourceChangeCreatedEventTests.cs
+++ b/tests/EiffelEvents.Net.Tests/Events/Edition-Paris/EiffelSourceChangeCreatedEventTests.cs
@@ -48,7 +48,7 @@ namespace EiffelEvents.Net.Tests.Events.Edition_Paris
         public void Validate_MissingRequired_Failed()
         {
             //Arrange
-            var sourceChangeCreatedEvent = new EiffelSourceChangeCreatedEvent();
+            var sourceChangeCreatedEvent = _eventFixture.GetMissedRequiredEvent();
 
             //Act
             var result = sourceChangeCreatedEvent.Validate();

--- a/tests/EiffelEvents.Net.Tests/Events/Edition-Paris/EiffelSourceChangeSubmittedEventTests.cs
+++ b/tests/EiffelEvents.Net.Tests/Events/Edition-Paris/EiffelSourceChangeSubmittedEventTests.cs
@@ -48,7 +48,7 @@ namespace EiffelEvents.Net.Tests.Events.Edition_Paris
         public void Validate_MissingRequired_Failed()
         {
             //Arrange
-            var sourceChangeSubmittedEvent = new EiffelSourceChangeSubmittedEvent();
+            var sourceChangeSubmittedEvent = _eventFixture.GetMissedRequiredEvent();
 
             //Act
             var result = sourceChangeSubmittedEvent.Validate();

--- a/tests/EiffelEvents.Net.Tests/TestData/Edition-Lyon/EiffelActivityCanceledEventFixture.cs
+++ b/tests/EiffelEvents.Net.Tests/TestData/Edition-Lyon/EiffelActivityCanceledEventFixture.cs
@@ -1,0 +1,81 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+using EiffelEvents.Net.Events.Edition_Lyon;
+
+namespace EiffelEvents.Net.Tests.TestData.Edition_Lyon
+{
+    public class EiffelActivityCanceledEventFixture
+    {
+        /// <summary>
+        /// Get a complete valid instance of EiffelActivityCanceledEvent.
+        /// </summary>
+        /// <returns></returns>
+        public EiffelActivityCanceledEvent GetValidCompleteEvent()
+        {
+            return new EiffelActivityCanceledEvent()
+            {
+                Data = new()
+                {
+                    Reason = "some reasons",
+                    CustomData = new()
+                    {
+                        { "key1", "test" },
+                        { "key2", 1 }
+                    }
+                },
+                Meta = new()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Time = 1637001247776,
+                    Tags = new() { "activity_block" },
+                    Security = new()
+                    {
+                        AuthorIdentity = "Flower"
+                    }
+                },
+                Links = new()
+                {
+                    Cause = new()
+                    {
+                        new()
+                        {
+                            Target = Guid.NewGuid().ToString(),
+                            DomainId = "test-domain-id"
+                        },
+                        new()
+                        {
+                            Target = Guid.NewGuid().ToString()
+                        }
+                    },
+                    Context = new()
+                    {
+                        Target = Guid.NewGuid().ToString(),
+                        DomainId = "test-domain-id"
+                    },
+                    FlowContext = new()
+                    {
+                        new()
+                        {
+                            Target = Guid.NewGuid().ToString(),
+                            DomainId = "test-domain-id"
+                        }
+                    },
+                    ActivityExecution = new(Guid.NewGuid().ToString(), "test-domain-id")
+                }
+            };
+        }
+    }
+}

--- a/tests/EiffelEvents.Net.Tests/TestData/Edition-Lyon/EiffelActivityStartedEventFixture.cs
+++ b/tests/EiffelEvents.Net.Tests/TestData/Edition-Lyon/EiffelActivityStartedEventFixture.cs
@@ -1,0 +1,97 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+using EiffelEvents.Net.Events.Edition_Lyon;
+using EiffelEvents.Net.Events.Edition_Lyon.Shared.Data;
+
+namespace EiffelEvents.Net.Tests.TestData.Edition_Lyon
+{
+    public class EiffelActivityStartedEventFixture
+    {
+        /// <summary>
+        /// Get a complete valid instance of EiffelActivityStartedEvent.
+        /// </summary>
+        /// <returns></returns>
+        public EiffelActivityStartedEvent GetValidCompleteEvent()
+        {
+            return new EiffelActivityStartedEvent()
+            {
+                Data = new()
+                {
+                    ExecutionUri = "https://my.jenkins.host/myJob/43",
+                    LiveLogs = new()
+                    {
+                        new ()
+                        {
+                            Name = "My build log",
+                            MediaType = "text/plain",
+                            Uri = "file:///tmp/logs/data.log",
+                            Tags = new(){"build"}
+                        }
+                    },
+                    CustomData = new()
+                    {
+                        { "key1", "test" },
+                        { "key2", 1 }
+                    }
+                },
+                Meta = new()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Time = 1637001247776,
+                    Tags = new() { "activity_block" },
+                    Security = new()
+                    {
+                        AuthorIdentity = "Flower"
+                    }
+                },
+                Links = new()
+                {
+                    Cause = new()
+                    {
+                        new()
+                        {
+                            Target = Guid.NewGuid().ToString(),
+                            DomainId = "test-domain-id"
+                        },
+                        new()
+                        {
+                            Target = Guid.NewGuid().ToString()
+                        }
+                    },
+                    Context = new()
+                    {
+                        Target = Guid.NewGuid().ToString(),
+                        DomainId = "test-domain-id"
+                    },
+                    FlowContext = new()
+                    {
+                        new()
+                        {
+                            Target = Guid.NewGuid().ToString(),
+                            DomainId = "test-domain-id"
+                        }
+                    },
+                    ActivityExecution = new(Guid.NewGuid().ToString(), "test-domain-id"),
+                    PreviousActivityExecution = new()
+                    {
+                        DomainId = "test-domain-id",
+                        Target = Guid.NewGuid().ToString()
+                    }
+                }
+            };
+        }
+    }
+}

--- a/tests/EiffelEvents.Net.Tests/TestData/Edition-Lyon/EiffelActivityTriggeredEventFixture.cs
+++ b/tests/EiffelEvents.Net.Tests/TestData/Edition-Lyon/EiffelActivityTriggeredEventFixture.cs
@@ -630,6 +630,99 @@ namespace EiffelEvents.Net.Tests.TestData.Edition_Lyon
         }
 
         #endregion
+        
+        #region Valid Event empty Links (ICollection types)
+
+        /// <summary>
+        /// Get a valid instance of EiffelActivityTriggeredEvent with empty Links.
+        /// </summary>
+        /// <returns></returns>
+        public EiffelActivityTriggeredEvent GetEventWithEmptyLinks()
+        {
+             return new EiffelActivityTriggeredEvent()
+            {
+                Data = new()
+                {
+                    Name = "My activity",
+                    Categories = new() { "category 1", "category 2" },
+                    Triggers = new()
+                    {
+                        new()
+                        {
+                            Type = EiffelDataTriggerType.SOURCE_CHANGE,
+                            Description = "Description"
+                        }
+                    },
+                    ExecutionType = EiffelDataExecutionType.AUTOMATED,
+                    CustomData = new()
+                    {
+                        { "key1", "test" },
+                        { "key2", 1 }
+                    }
+                },
+                Meta = new()
+                {
+                    Id = "91d0c7da-8d90-4033-8685-a035853aeea1",
+                    Time = 1637001247776,
+                    Tags = new() { "activity_block" },
+                    Security = new()
+                    {
+                        AuthorIdentity = "Flower"
+                    }
+                },
+                Links = new()
+                
+            };
+        }
+
+        public string GetEventWithEmptyLinksSerialized()
+        {
+            var json = JObject.Parse(@"{
+                              'data': {
+                                        'name': 'My activity',
+                                        'categories': [
+                                        'category 1',
+                                        'category 2'
+                                            ],
+                                        'triggers': [
+                                        {
+                                            'type': 'SOURCE_CHANGE',
+                                            'description': 'Description'
+                                        }
+                                        ],
+                                        'executionType': 'AUTOMATED',
+                                         'customData': [
+                                            {
+                                                'key': 'key1',
+                                                'value': 'test'
+                                            },
+                                            {
+                                                'key': 'key2',
+                                                'value': 1
+                                            }
+                                            ]
+                                    },
+                                    'meta': {
+                                        'type': 'EiffelActivityTriggeredEvent',
+                                        'version': '4.1.0',
+                                        'tags': [
+                                        'activity_block'
+                                            ],
+                                        'source': {
+                                                    'serializer': 'pkg:nuget/EiffelEvents.Net@1.0.0.0'
+                                         },
+                                        'security': {
+                                            'authorIdentity': 'Flower'
+                                        },
+                                        'id': '91d0c7da-8d90-4033-8685-a035853aeea1',
+                                        'time': 1637001247776
+                                    },
+                                'links': [ ]
+                            }");
+            return json.ToString();
+        }
+
+        #endregion
 
         #region Not Valid Guids
 

--- a/tests/EiffelEvents.Net.Tests/TestData/Edition-Paris/EiffelActivityTriggeredEventFixture.cs
+++ b/tests/EiffelEvents.Net.Tests/TestData/Edition-Paris/EiffelActivityTriggeredEventFixture.cs
@@ -508,6 +508,71 @@ namespace EiffelEvents.Net.Tests.TestData.Edition_Paris
         }
 
         #endregion
+        
+        #region Valid Event empty Links (ICollection types)
+
+        /// <summary>
+        /// Get a valid instance of EiffelActivityTriggeredEvent with empty Links.
+        /// </summary>
+        /// <returns></returns>
+        public EiffelActivityTriggeredEvent GetEventWithEmptyLinks()
+        {
+            return new EiffelActivityTriggeredEvent()
+            {
+                Data = new()
+                {
+                    Name = "My activity",
+                    Categories = new() { "category 1", "category 2" },
+                    Triggers = new(),
+                    ExecutionType = EiffelDataExecutionType.AUTOMATED,
+                    CustomData = new()
+                },
+                Meta = new()
+                {
+                    Id = "91d0c7da-8d90-4033-8685-a035853aeea1",
+                    Time = 1637001247776,
+                    Tags = new() { "activity_block" },
+                    Security = new()
+                    {
+                        AuthorIdentity = "Flower"
+                    }
+                },
+                Links = new()
+            };
+        }
+
+        public string GetEventWithEmptyLinksSerialized()
+        {
+            var json = JObject.Parse(@"{
+                              'data': {
+                                        'name': 'My activity',
+                                        'categories': [
+                                        'category 1',
+                                        'category 2'
+                                            ],
+                                        'executionType': 'AUTOMATED'
+                                    },
+                                    'meta': {
+                                        'type': 'EiffelActivityTriggeredEvent',
+                                        'version': '4.0.0',
+                                        'tags': [
+                                        'activity_block'
+                                            ],
+                                        'source': {
+                                                    'serializer': 'pkg:nuget/EiffelEvents.Net@1.0.0.0'
+                                         },
+                                        'security': {
+                                            'authorIdentity': 'Flower'
+                                        },
+                                        'id': '91d0c7da-8d90-4033-8685-a035853aeea1',
+                                        'time': 1637001247776
+                                    },
+                                'links': [ ]
+                            }");
+            return json.ToString();
+        }
+
+        #endregion
 
         #region Not Valid Guids
 

--- a/tests/EiffelEvents.Net.Tests/TestData/Edition-Paris/EiffelFlowContextDefinedEventFixture.cs
+++ b/tests/EiffelEvents.Net.Tests/TestData/Edition-Paris/EiffelFlowContextDefinedEventFixture.cs
@@ -60,5 +60,19 @@ namespace EiffelEvents.Net.Tests.TestData.Edition_Paris
                 }
             };
         }
+        
+        /// <summary>
+        /// Get a invalid instance of EiffelFlowContextDefinedEvent.
+        /// </summary>
+        /// <returns></returns>
+        public EiffelFlowContextDefinedEvent GetMissedRequiredEvent()
+        {
+            return new EiffelFlowContextDefinedEvent
+            {
+                Data = null,
+                Meta = null,
+                Links = null
+            };
+        }
     }
 }

--- a/tests/EiffelEvents.Net.Tests/TestData/Edition-Paris/EiffelSourceChangeCreatedEventFixture.cs
+++ b/tests/EiffelEvents.Net.Tests/TestData/Edition-Paris/EiffelSourceChangeCreatedEventFixture.cs
@@ -78,5 +78,19 @@ namespace EiffelEvents.Net.Tests.TestData.Edition_Paris
                 }
             };
         }
+        
+        /// <summary>
+        /// Get a invalid instance of EiffelSourceChangeCreatedEvent.
+        /// </summary>
+        /// <returns></returns>
+        public EiffelSourceChangeCreatedEvent GetMissedRequiredEvent()
+        {
+            return new EiffelSourceChangeCreatedEvent
+            {
+                Data = null,
+                Meta = null,
+                Links = null
+            };
+        }
     }
 }

--- a/tests/EiffelEvents.Net.Tests/TestData/Edition-Paris/EiffelSourceChangeSubmittedEventFixture.cs
+++ b/tests/EiffelEvents.Net.Tests/TestData/Edition-Paris/EiffelSourceChangeSubmittedEventFixture.cs
@@ -74,5 +74,19 @@ namespace EiffelEvents.Net.Tests.TestData.Edition_Paris
                 }
             };
         }
+        
+        /// <summary>
+        /// Get a invalid instance of EiffelSourceChangeSubmittedEvent.
+        /// </summary>
+        /// <returns></returns>
+        public EiffelSourceChangeSubmittedEvent GetMissedRequiredEvent()
+        {
+            return new EiffelSourceChangeSubmittedEvent
+            {
+                Data = null,
+                Meta = null,
+                Links = null
+            };
+        }
     }
 }


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
This pull request resolves #23 to add EiffelActivityStartedEvent for Lyon edition.

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->

- Add EiffelActivityStartedEvent lyon edition.
- Add EiffelActivityStartedEvent lyon edition tests.
- Add EiffelActivityStartedEvent lyon edition samples.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->
Support Lyon edition.
### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
N/A
### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Ahmed Abou Elfotouh ahmed.fotouh@live.com
