### PR TITLE
Lyon add eiffel artifiact reused

### DIFF
--- a/examples/EiffelClient.PublisherOne/Models/Edition-Lyon/ArtifactReused.cs
+++ b/examples/EiffelClient.PublisherOne/Models/Edition-Lyon/ArtifactReused.cs
@@ -1,0 +1,57 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+using EiffelEvents.Net.Events.Edition_Lyon;
+
+namespace EiffelClient.PublisherOne.Models.Edition_Lyon
+{
+    public class ArtifactReused
+    {
+        public static EiffelArtifactReusedEvent GetEvent()
+        {
+            return new EiffelArtifactReusedEvent
+            {
+                Data = new()
+                {
+                    CustomData = new()
+                    {
+                        { "key1", "test" },
+                        { "key2", new[] { 1, 2, 3 } }
+                    }
+                },
+                Meta = new()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Tags = new() { "artifact reused" },
+                    Security = new()
+                    {
+                        AuthorIdentity = "Flower"
+                    }
+                },
+                Links = new EiffelArtifactReusedLinks
+                {
+                    Composition = new("82f11609-bd5b-4c82-a5f2-c2a9d982cdbd"),
+                    ReusedArtifact = new("cf056717-201b-43f6-9f2c-839b33b71baf"),
+                    Cause = new()
+                    {
+                        new(Guid.NewGuid().ToString()),
+                        new(Guid.NewGuid().ToString()),
+                        new(Guid.NewGuid().ToString())
+                    }
+                }
+            };
+        }
+    }
+}

--- a/examples/EiffelClient.PublisherOne/Models/Edition-Lyon/Client.cs
+++ b/examples/EiffelClient.PublisherOne/Models/Edition-Lyon/Client.cs
@@ -39,7 +39,7 @@ namespace EiffelClient.PublisherOne.Models.Edition_Lyon
                 nameof(EiffelActivityCanceledEvent) => ActivityCanceled.GetEvent() as T,
                 nameof(EiffelActivityFinishedEvent) => ActivityFinished.GetEvent() as T,
                 nameof(EiffelArtifactCreatedEvent) => ArtifactCreated.GetEvent() as T,
-                // nameof(EiffelArtifactReusedEvent) => ArtifactReused.GetEvent() as T,
+                nameof(EiffelArtifactReusedEvent) => ArtifactReused.GetEvent() as T,
                 nameof(EiffelArtifactPublishedEvent) => ArtifactPublished.GetEvent() as T,
                 // nameof(EiffelConfidenceLevelModifiedEvent) => ConfidenceLevelModified.GetEvent() as T,
                 // nameof(EiffelEnvironmentDefinedEvent) => EnvironmentDefined.GetEvent() as T,

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityFinishedEvent/EiffelActivityFinishedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelActivityFinishedEvent/EiffelActivityFinishedEvent.cs
@@ -28,14 +28,14 @@ namespace EiffelEvents.Net.Events.Edition_Lyon
         EiffelEvent<EiffelActivityFinishedData, EiffelActivityFinishedMeta, EiffelActivityFinishedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelActivityFinishedData Data { get; init; }
-        
+        public override EiffelActivityFinishedData Data { get; init; } = new();
+
         /// <inheritdoc/>
-        public override EiffelActivityFinishedMeta Meta { get; init; }
-        
+        public override EiffelActivityFinishedMeta Meta { get; init; } = new();
+
         /// <inheritdoc/>
-        public override EiffelActivityFinishedLinks Links { get; init; }
-        
+        public override EiffelActivityFinishedLinks Links { get; init; } = new();
+
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)
         {

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelArtifactReusedEvent/EiffelArtifactReusedData.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelArtifactReusedEvent/EiffelArtifactReusedData.cs
@@ -14,5 +14,5 @@
 
 namespace EiffelEvents.Net.Events.Edition_Lyon
 {
-    public record EiffelArtifactReusedData : Edition_Paris.EiffelArtifactCreatedData;
+    public record EiffelArtifactReusedData : Edition_Paris.EiffelArtifactReusedData;
 }

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelArtifactReusedEvent/EiffelArtifactReusedData.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelArtifactReusedEvent/EiffelArtifactReusedData.cs
@@ -1,0 +1,18 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+namespace EiffelEvents.Net.Events.Edition_Lyon
+{
+    public record EiffelArtifactReusedData : Edition_Paris.EiffelArtifactCreatedData;
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelArtifactReusedEvent/EiffelArtifactReusedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelArtifactReusedEvent/EiffelArtifactReusedEvent.cs
@@ -27,14 +27,14 @@ namespace EiffelEvents.Net.Events.Edition_Lyon
         EiffelEvent<EiffelArtifactReusedData, EiffelArtifactReusedMeta, EiffelArtifactReusedLinks>
     {
         /// <inheritdoc/>
-        public override EiffelArtifactReusedData Data { get; init; }
-        
+        public override EiffelArtifactReusedData Data { get; init; } = new();
+
         /// <inheritdoc/>
-        public override EiffelArtifactReusedMeta Meta { get; init; }
-        
+        public override EiffelArtifactReusedMeta Meta { get; init; } = new();
+
         /// <inheritdoc/>
-        public override EiffelArtifactReusedLinks Links { get; init; }
-        
+        public override EiffelArtifactReusedLinks Links { get; init; } = new();
+
         /// <inheritdoc/>
         public override IEiffelEvent FromJson(string json)
         {

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelArtifactReusedEvent/EiffelArtifactReusedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelArtifactReusedEvent/EiffelArtifactReusedEvent.cs
@@ -1,0 +1,44 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using EiffelEvents.Net.Events.Core;
+using EiffelEvents.Net.Events.Edition_Lyon.Shared;
+
+namespace EiffelEvents.Net.Events.Edition_Lyon
+{
+    /// <summary>
+    /// The <a href="https://github.com/eiffel-community/eiffel/blob/edition-lyon/eiffel-vocabulary/EiffelArtifactReusedEvent.md">
+    /// EiffelArtifactReusedEvent
+    /// </a> declares that an identified EiffelArtifactCreatedEvent has been reused for
+    /// an identified EiffelCompositionDefinedEvent. 
+    /// </summary>
+    public record EiffelArtifactReusedEvent :
+        EiffelEvent<EiffelArtifactReusedData, EiffelArtifactReusedMeta, EiffelArtifactReusedLinks>
+    {
+        /// <inheritdoc/>
+        public override EiffelArtifactReusedData Data { get; init; }
+        
+        /// <inheritdoc/>
+        public override EiffelArtifactReusedMeta Meta { get; init; }
+        
+        /// <inheritdoc/>
+        public override EiffelArtifactReusedLinks Links { get; init; }
+        
+        /// <inheritdoc/>
+        public override IEiffelEvent FromJson(string json)
+        {
+            return Deserialize<EiffelArtifactReusedEvent>(json);
+        }
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelArtifactReusedEvent/EiffelArtifactReusedLinks.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelArtifactReusedEvent/EiffelArtifactReusedLinks.cs
@@ -1,0 +1,36 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using EiffelEvents.Net.Events.Edition_Lyon.Shared;
+using EiffelEvents.Net.Events.Edition_Lyon.Shared.Links;
+
+namespace EiffelEvents.Net.Events.Edition_Lyon
+{
+    public record EiffelArtifactReusedLinks : EiffelSharedLinks
+    {
+        /// <summary>
+        /// Identifies the composition for which an already existing artifact (identified by REUSED_ARTIFACT)
+        /// is declared reused.
+        /// Legal targets: EiffelCompositionDefinedEvent
+        /// </summary>
+        public EiffelCompositionLink Composition { get; init; }
+        
+        /// <summary>
+        /// This link identifies the EiffelArtifactCreatedEvent that is reused for the composition identified by
+        /// COMPOSITION; in other words, the artifact that is not rebuilt for a that composition.
+        /// Legal targets: EiffelArtifactCreatedEvent
+        /// </summary>
+        public EiffelReusedArtifactLink ReusedArtifact { get; init; }
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelArtifactReusedEvent/EiffelArtifactReusedLinks.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelArtifactReusedEvent/EiffelArtifactReusedLinks.cs
@@ -12,8 +12,10 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+using System.ComponentModel.DataAnnotations;
 using EiffelEvents.Net.Events.Edition_Lyon.Shared;
 using EiffelEvents.Net.Events.Edition_Lyon.Shared.Links;
+using EiffelEvents.Net.Validation;
 
 namespace EiffelEvents.Net.Events.Edition_Lyon
 {
@@ -24,6 +26,8 @@ namespace EiffelEvents.Net.Events.Edition_Lyon
         /// is declared reused.
         /// Legal targets: EiffelCompositionDefinedEvent
         /// </summary>
+        [Required]
+        [NestedObject]
         public EiffelCompositionLink Composition { get; init; }
         
         /// <summary>
@@ -31,6 +35,8 @@ namespace EiffelEvents.Net.Events.Edition_Lyon
         /// COMPOSITION; in other words, the artifact that is not rebuilt for a that composition.
         /// Legal targets: EiffelArtifactCreatedEvent
         /// </summary>
+        [Required]
+        [NestedObject]
         public EiffelReusedArtifactLink ReusedArtifact { get; init; }
     }
 }

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelArtifactReusedEvent/EiffelArtifactReusedMeta.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelArtifactReusedEvent/EiffelArtifactReusedMeta.cs
@@ -1,0 +1,23 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using EiffelEvents.Net.Events.Edition_Lyon.Shared;
+
+namespace EiffelEvents.Net.Events.Edition_Lyon;
+
+public record EiffelArtifactReusedMeta : EiffelSharedMeta
+{
+    public override string Type { get; init; } = nameof(EiffelArtifactReusedEvent);
+    public override string Version { get; init; } = "3.1.0";
+}

--- a/tests/EiffelEvents.Net.Tests/Events/Edition-Lyon/EiffelArtifactReusedEventTests.cs
+++ b/tests/EiffelEvents.Net.Tests/Events/Edition-Lyon/EiffelArtifactReusedEventTests.cs
@@ -1,0 +1,91 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+using EiffelEvents.Net.Events.Edition_Lyon;
+using EiffelEvents.Net.Tests.TestData.Edition_Lyon;
+using FluentAssertions;
+using FluentResults;
+using Xunit;
+
+namespace EiffelEvents.Net.Tests.Events.Edition_Lyon
+{
+    public class EiffelArtifactReusedEventTests:IClassFixture<EiffelArtifactReusedEventFixture>
+    {
+        private readonly EiffelArtifactReusedEventFixture _eventFixture;
+        public EiffelArtifactReusedEventTests(EiffelArtifactReusedEventFixture fixture)
+        {
+            _eventFixture = fixture;
+        }
+        
+        [Fact]
+        public void Validate_CompleteAttributes_Success()
+        {
+            //Arrange
+            var artifactReusedEvent = _eventFixture.GetValidCompleteEvent();
+            
+            //Act
+            Result result = artifactReusedEvent.Validate();
+
+            //Assert
+            result.IsSuccess.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_MissingRequired_Failed()
+        {
+            //Arrange
+            var artifactReusedEvent = new EiffelArtifactReusedEvent();
+
+            //Act
+            var result = artifactReusedEvent.Validate();
+
+            //Assert
+            result.IsSuccess.Should().BeFalse();
+        }
+        
+        [Fact]
+        public void VerifySignature_ValidSignature_Success()
+        {
+            //Arrange
+            var artifactReusedEvent = _eventFixture.GetValidCompleteEvent();
+
+            //Act
+            var artifactReusedEventSigned = artifactReusedEvent.Sign<EiffelArtifactReusedEvent>();
+
+            //Assert
+            artifactReusedEventSigned.VerifySignature().Should().BeTrue();
+        }
+
+        [Fact]
+        public void VerifySignature_CorruptedObject_Failed()
+        {
+            //Arrange
+            var artifactReusedEvent = _eventFixture.GetValidCompleteEvent();
+
+            //Act
+            var artifactReusedEventSigned = artifactReusedEvent.Sign<EiffelArtifactReusedEvent>();
+            artifactReusedEventSigned = artifactReusedEventSigned with
+            {
+                Meta = artifactReusedEventSigned.Meta with
+                {
+                    Id = Guid.NewGuid().ToString()
+                }
+            };
+            
+            //Assert
+            artifactReusedEventSigned.VerifySignature().Should().BeFalse();
+        }
+    }
+}

--- a/tests/EiffelEvents.Net.Tests/TestData/Edition-Lyon/EiffelArtifactReusedEventFixture.cs
+++ b/tests/EiffelEvents.Net.Tests/TestData/Edition-Lyon/EiffelArtifactReusedEventFixture.cs
@@ -1,0 +1,61 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+using EiffelEvents.Net.Events.Edition_Lyon;
+
+namespace EiffelEvents.Net.Tests.TestData.Edition_Lyon
+{
+    public class EiffelArtifactReusedEventFixture
+    {
+        /// <summary>
+        /// Get a complete valid instance of EiffelArtifactReusedEvent.
+        /// </summary>
+        /// <returns></returns>
+        public EiffelArtifactReusedEvent GetValidCompleteEvent()
+        {
+            return new EiffelArtifactReusedEvent
+            {
+                Data = new()
+                {
+                    CustomData = new()
+                    {
+                        { "key1", "test" },
+                        { "key2", new[] { 1, 2, 3 } }
+                    }
+                },
+                Meta = new()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Tags = new() { "artifact reused" },
+                    Security = new()
+                    {
+                        AuthorIdentity = "Flower"
+                    }
+                },
+                Links = new EiffelArtifactReusedLinks
+                {
+                    Composition = new("82f11609-bd5b-4c82-a5f2-c2a9d982cdbd"),
+                    ReusedArtifact = new("cf056717-201b-43f6-9f2c-839b33b71baf"),
+                    Cause = new()
+                    {
+                        new(Guid.NewGuid().ToString()),
+                        new(Guid.NewGuid().ToString()),
+                        new(Guid.NewGuid().ToString())
+                    }
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
### Applicable Issues
This PR resolves #27 

### Description of the Change
Adding EiffelArtificatReusedEvent 

### Benefits
Support Lyon Edition

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fady Kamil engfadykamil.2014@gmail.com
