### PR TITLE
Lyon add eiffel test case started

### DIFF
--- a/examples/EiffelClient.PublisherOne/Models/Edition-Lyon/Client.cs
+++ b/examples/EiffelClient.PublisherOne/Models/Edition-Lyon/Client.cs
@@ -53,7 +53,7 @@ namespace EiffelClient.PublisherOne.Models.Edition_Lyon
                 nameof(EiffelTestCaseCanceledEvent) => TestCaseCanceled.GetEvent() as T,
                 // nameof(EiffelTestCaseFinishedEvent) => TestCaseFinished.GetEvent() as T,
                 // nameof(EiffelIssueVerifiedEvent) => IssueVerified.GetEvent() as T,
-                // nameof(EiffelTestCaseStartedEvent) => TestCaseStarted.GetEvent() as T,
+                nameof(EiffelTestCaseStartedEvent) => TestCaseStarted.GetEvent() as T,
                 // nameof(EiffelIssueDefinedEvent) => IssueDefined.GetEvent() as T,
                 // nameof(EiffelAnnouncementPublishedEvent) => AnnouncementPublished.GetEvent() as T,
                 // nameof(EiffelTestExecutionRecipeCollectionCreatedEvent) =>

--- a/examples/EiffelClient.PublisherOne/Models/Edition-Lyon/TestCaseStarted.cs
+++ b/examples/EiffelClient.PublisherOne/Models/Edition-Lyon/TestCaseStarted.cs
@@ -1,0 +1,61 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using EiffelEvents.Net.Events.Edition_Lyon;
+
+namespace EiffelClient.PublisherOne.Models.Edition_Lyon
+{
+    public class TestCaseStarted
+    {
+        public static EiffelTestCaseStartedEvent GetEvent()
+        {
+            return new EiffelTestCaseStartedEvent
+            {
+                Data = new()
+                {
+                    Executor = "Test",
+                    LiveLogs = new()
+                    {
+                        new()
+                        {
+                            Name = "Log1",
+                            Uri = "Log1.log"
+                        }
+                    },
+                    CustomData = new()
+                    {
+                        { "key1", "test" },
+                        { "key2", new[] { 1, 2, 3 } }
+                    }
+                },
+                Meta = new()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Tags = new List<string> { "docker env" },
+                    Security = new ()
+                    {
+                        AuthorIdentity = "Flower"
+                    }
+                },
+                Links = new()
+                {
+                    TestCaseExecution = new(Guid.NewGuid().ToString()),
+                    Environment = new(Guid.NewGuid().ToString())
+                }
+            };
+        }
+    }
+}

--- a/examples/EiffelClient.PublisherOne/Program.cs
+++ b/examples/EiffelClient.PublisherOne/Program.cs
@@ -26,8 +26,8 @@ namespace EiffelClient.PublisherOne
             Console.WriteLine("Started !!");
 
             // Create a raw event
-            var eiffelEvent = TryClient.GetEvent<EiffelTestCaseCanceledEvent>();
-            var signedEvent = eiffelEvent?.Sign<EiffelTestCaseCanceledEvent>();
+            var eiffelEvent = TryClient.GetEvent<EiffelTestCaseStartedEvent>();
+            var signedEvent = eiffelEvent?.Sign<EiffelTestCaseStartedEvent>();
 
           /*for (int i = 0; i < 10000; i++)
            {*/

--- a/examples/EiffelClient.SubscriberOne/Program.cs
+++ b/examples/EiffelClient.SubscriberOne/Program.cs
@@ -41,8 +41,8 @@ namespace EiffelClient.SubscriberOne
             Console.WriteLine("Started ....");
 
             // Subscribe to events
-            _subscriptionId = _client.Subscribe<EiffelTestCaseCanceledEvent>(_queueIdentifier, GeneralHandleEvent);
-            Console.WriteLine($"Subscription done to event {nameof(EiffelTestCaseCanceledEvent)} !");
+            _subscriptionId = _client.Subscribe<EiffelTestCaseStartedEvent>(_queueIdentifier, GeneralHandleEvent);
+            Console.WriteLine($"Subscription done to event {nameof(EiffelTestCaseStartedEvent)} !");
 
             while (true)
             {

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelTestCaseStartedEvent/EiffelTestCaseStartedData.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelTestCaseStartedEvent/EiffelTestCaseStartedData.cs
@@ -1,0 +1,39 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System.Collections.Generic;
+using EiffelEvents.Net.Events.Core.Data;
+using EiffelEvents.Net.Events.Edition_Lyon.Shared.Data;
+using EiffelEvents.Net.Validation;
+
+namespace EiffelEvents.Net.Events.Edition_Lyon
+{
+    public record EiffelTestCaseStartedData : EiffelData
+    {
+        /// <summary>
+        /// The name of the test case executor, if applicable.
+        /// This property can be used to identify tests executed by a particular test framework.
+        /// </summary>
+        public string Executor { get; init; }
+        
+        /// <summary>
+        /// An array of live log files available during execution. These shall not be presumed to be stored
+        /// persistently; in other words, once the test case execution has finished there is no guarantee that these
+        /// links are valid. Persistently stored logs shall be (re-)declared by EiffelTestCaseFinishedEvent.
+        /// </summary>
+        [NestedList]
+        public List<EiffelLiveLog> LiveLogs { get; init; }
+    }    
+}
+

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelTestCaseStartedEvent/EiffelTestCaseStartedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelTestCaseStartedEvent/EiffelTestCaseStartedEvent.cs
@@ -1,0 +1,44 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using EiffelEvents.Net.Events.Core;
+using EiffelEvents.Net.Events.Edition_Lyon.Shared;
+
+namespace EiffelEvents.Net.Events.Edition_Lyon
+{
+    /// <summary>
+    /// The <a href="https://github.com/eiffel-community/eiffel/blob/edition-lyon/eiffel-vocabulary/EiffelTestCaseStartedEvent.md">
+    /// EiffelTestCaseStartedEvent
+    /// </a> declares that the execution of a test case has commenced. This event SHALL be
+    /// preceded by a EiffelTestCaseTriggeredEvent, and appropriately linked to via TEST_CASE_EXECUTION.
+    /// </summary>
+    public record EiffelTestCaseStartedEvent :
+        EiffelEvent<EiffelTestCaseStartedData, EiffelTestCaseStartedMeta, EiffelTestCaseStartedLinks>
+    {
+        /// <inheritdoc/>
+        public override EiffelTestCaseStartedData Data { get; init; } = new();
+        
+        /// <inheritdoc/>
+        public override EiffelTestCaseStartedMeta Meta { get; init; } = new();
+        
+        /// <inheritdoc/>
+        public override EiffelTestCaseStartedLinks Links { get; init; } = new();
+
+        /// <inheritdoc/>
+        public override IEiffelEvent FromJson(string json)
+        {
+            return Deserialize<EiffelTestCaseStartedEvent>(json);
+        }
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelTestCaseStartedEvent/EiffelTestCaseStartedLinks.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelTestCaseStartedEvent/EiffelTestCaseStartedLinks.cs
@@ -1,0 +1,43 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System.ComponentModel.DataAnnotations;
+using EiffelEvents.Net.Events.Edition_Lyon.Shared;
+using EiffelEvents.Net.Events.Edition_Lyon.Shared.Links;
+using EiffelEvents.Net.Validation;
+
+namespace EiffelEvents.Net.Events.Edition_Lyon
+{
+    public record EiffelTestCaseStartedLinks : EiffelSharedLinks
+    {
+        /// <summary>
+        /// Identifies the relevant test case execution. In other words, EiffelTestCaseTriggeredEvent acts as a handle
+        /// for a particular test case execution. This differs from CONTEXT. In TEST_CASE_EXECUTION the source carries
+        /// information pertaining to the target (i.e. the test case execution started, finished or was canceled).
+        /// In CONTEXT, on the other hand, the source constitutes a subset of the target (e.g. this test case was
+        /// executed as part of that activity or test suite).
+        /// Legal targets: EiffelTestCaseTriggeredEvent
+        /// </summary>
+        [Required]
+        [NestedObject]
+        public EiffelTestCaseExecutionLink TestCaseExecution { get; init; }
+
+        /// <summary>
+        /// Identifies the environment in which the test case is being executed.
+        /// Legal targets: EiffelEnvironmentDefinedEvent
+        /// </summary>
+        [NestedObject]
+        public EiffelEnvironmentLink Environment { get; init; }
+    }    
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelTestCaseStartedEvent/EiffelTestCaseStartedMeta.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelTestCaseStartedEvent/EiffelTestCaseStartedMeta.cs
@@ -1,0 +1,24 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using EiffelEvents.Net.Events.Edition_Lyon.Shared;
+
+namespace EiffelEvents.Net.Events.Edition_Lyon
+{
+    public record EiffelTestCaseStartedMeta : EiffelSharedMeta
+    {
+        public override string Type { get; init; } = nameof(EiffelTestCaseStartedEvent);
+        public override string Version { get; init; } = "3.2.0";
+    }    
+}

--- a/tests/EiffelEvents.Net.Tests/Events/Edition-Lyon/EiffelTestCaseStartedEventTests.cs
+++ b/tests/EiffelEvents.Net.Tests/Events/Edition-Lyon/EiffelTestCaseStartedEventTests.cs
@@ -1,0 +1,92 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+using EiffelEvents.Net.Events.Edition_Lyon;
+using EiffelEvents.Net.Tests.TestData.Edition_Lyon;
+using FluentAssertions;
+using FluentResults;
+using Xunit;
+
+namespace EiffelEvents.Net.Tests.Events.Edition_Lyon
+{
+    public class EiffelTestCaseStartedEventTests : IClassFixture<EiffelTestCaseStartedEventFixture>
+    {
+        private readonly EiffelTestCaseStartedEventFixture _eventFixture;
+
+        public EiffelTestCaseStartedEventTests(EiffelTestCaseStartedEventFixture fixture)
+        {
+            _eventFixture = fixture;
+        }
+
+        [Fact]
+        public void Validate_CompleteAttributes_Success()
+        {
+            //Arrange
+            var testCaseStartedEvent = _eventFixture.GetValidCompleteEvent();
+
+            //Act
+            Result result = testCaseStartedEvent.Validate();
+
+            //Assert
+            result.IsSuccess.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_MissingRequired_Failed()
+        {
+            //Arrange
+            var testCaseStartedEvent = new EiffelTestCaseStartedEvent();
+
+            //Act
+            var result = testCaseStartedEvent.Validate();
+
+            //Assert
+            result.IsSuccess.Should().BeFalse();
+        }
+
+        [Fact]
+        public void VerifySignature_ValidSignature_Success()
+        {
+            //Arrange
+            var testCaseStartedEvent = _eventFixture.GetValidCompleteEvent();
+
+            //Act
+            var testCaseStartedEventSigned = testCaseStartedEvent.Sign<EiffelTestCaseStartedEvent>();
+
+            //Assert
+            testCaseStartedEventSigned.VerifySignature().Should().BeTrue();
+        }
+
+        [Fact]
+        public void VerifySignature_CorruptedObject_Failed()
+        {
+            //Arrange
+            var testCaseStartedEvent = _eventFixture.GetValidCompleteEvent();
+
+            //Act
+            var testCaseStartedEventSigned = testCaseStartedEvent.Sign<EiffelTestCaseStartedEvent>();
+            testCaseStartedEventSigned = testCaseStartedEventSigned with
+            {
+                Meta = testCaseStartedEventSigned.Meta with
+                {
+                    Id = Guid.NewGuid().ToString()
+                }
+            };
+
+            //Assert
+            testCaseStartedEventSigned.VerifySignature().Should().BeFalse();
+        }
+    }
+}

--- a/tests/EiffelEvents.Net.Tests/TestData/Edition-Lyon/EiffelTestCaseStartedEventFixture.cs
+++ b/tests/EiffelEvents.Net.Tests/TestData/Edition-Lyon/EiffelTestCaseStartedEventFixture.cs
@@ -1,0 +1,66 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using EiffelEvents.Net.Events.Edition_Lyon;
+using EiffelEvents.Net.Events.Edition_Paris.Shared.Security;
+
+namespace EiffelEvents.Net.Tests.TestData.Edition_Lyon
+{
+    public class EiffelTestCaseStartedEventFixture
+    {
+        /// <summary>
+        /// Get a complete valid instance of EiffelTestCaseStartedEvent.
+        /// </summary>
+        /// <returns></returns>
+        public EiffelTestCaseStartedEvent GetValidCompleteEvent()
+        {
+            return new EiffelTestCaseStartedEvent
+            {
+                Data = new()
+                {
+                    Executor = "Test",
+                    LiveLogs = new()
+                    {
+                        new()
+                        {
+                            Name = "Log1",
+                            Uri = "Log1.log"
+                        }
+                    },
+                    CustomData = new()
+                    {
+                        { "key1", "test" },
+                        { "key2", new[] { 1, 2, 3 } }
+                    }
+                },
+                Meta = new()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Tags = new List<string> { "docker env" },
+                    Security = new EiffelSecurity()
+                    {
+                        AuthorIdentity = "Flower"
+                    }
+                },
+                Links = new()
+                {
+                    TestCaseExecution = new(Guid.NewGuid().ToString()),
+                    Environment = new(Guid.NewGuid().ToString())
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
### Applicable Issues
This PR resolves #36.

### Description of the Change
- Add EiffelTestCaseStartedEvent Lyon edition.
- Add EiffelTestCaseStartedEvent Lyon edition test.
- Add EiffelTestCaseStartedEvent Lyon edition examples.

### Benefits
Support Lyon edition.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fady Kamil engfadykamil.2014@gmail.com
