### PR TITLE
Lyon add eiffel test suite started

### DIFF
--- a/examples/EiffelClient.PublisherOne/Models/Edition-Lyon/Client.cs
+++ b/examples/EiffelClient.PublisherOne/Models/Edition-Lyon/Client.cs
@@ -48,7 +48,7 @@ namespace EiffelClient.PublisherOne.Models.Edition_Lyon
                 nameof(EiffelFlowContextDefinedEvent) => FlowContextDefined.GetEvent() as T,
                 nameof(EiffelSourceChangeSubmittedEvent) => SourceChangeSubmitted.GetEvent() as T,
                 nameof(EiffelTestCaseTriggeredEvent) => TestCaseTriggered.GetEvent() as T,
-                // nameof(EiffelTestSuiteStartedEvent) => TestSuiteStarted.GetEvent() as T,
+                nameof(EiffelTestSuiteStartedEvent) => TestSuiteStarted.GetEvent() as T,
                 // nameof(EiffelTestSuiteFinishedEvent) => TestSuiteFinished.GetEvent() as T,
                 nameof(EiffelTestCaseCanceledEvent) => TestCaseCanceled.GetEvent() as T,
                 // nameof(EiffelTestCaseFinishedEvent) => TestCaseFinished.GetEvent() as T,

--- a/examples/EiffelClient.PublisherOne/Models/Edition-Lyon/TestSuiteStarted.cs
+++ b/examples/EiffelClient.PublisherOne/Models/Edition-Lyon/TestSuiteStarted.cs
@@ -1,0 +1,84 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using EiffelEvents.Net.Events.Edition_Lyon;
+using EiffelEvents.Net.Events.Edition_Paris.Shared.Enums;
+
+namespace EiffelClient.PublisherOne.Models.Edition_Lyon
+{
+    public class TestSuiteStarted
+    {
+        public static EiffelTestSuiteStartedEvent GetEvent()
+        {
+            return new EiffelTestSuiteStartedEvent
+            {
+                Data = new()
+                {
+                    Categories = new()
+                    {
+                        "category-1",
+                        "category-1"
+                    },
+                    LiveLogs = new()
+                    {
+                        new()
+                        {
+                            Name = "live-log-1",
+                            Uri = "livelog.xyz",
+                            MediaType = "Type 1",
+                            Tags = new() { "tag 1", "tag 2" }
+                        }
+                    },
+                    Name = "test-suite-1",
+                    Types = new()
+                    {
+                        EiffelDataTestingType.USABILITY,
+                        EiffelDataTestingType.SECURITY
+                    },
+                    CustomData = new()
+                    {
+                        { "key1", "test" },
+                        { "key2", new[] { 1, 2, 3 } }
+                    }
+                },
+                Meta = new()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Tags = new List<string> { "docker env" },
+                    Security = new()
+                    {
+                        AuthorIdentity = "Flower"
+                    }
+                },
+                Links = new()
+                {
+                    Terc = new(Guid.NewGuid().ToString()),
+                    Cause = new()
+                    {
+                        new(Guid.NewGuid().ToString()),
+                        new(Guid.NewGuid().ToString())
+                    },
+                    Context = new(Guid.NewGuid().ToString()),
+                    FlowContext = new()
+                    {
+                        new(Guid.NewGuid().ToString()),
+                        new(Guid.NewGuid().ToString())
+                    }
+                }
+            };
+        }
+    }
+}

--- a/examples/EiffelClient.PublisherOne/Program.cs
+++ b/examples/EiffelClient.PublisherOne/Program.cs
@@ -26,8 +26,8 @@ namespace EiffelClient.PublisherOne
             Console.WriteLine("Started !!");
 
             // Create a raw event
-            var eiffelEvent = TryClient.GetEvent<EiffelTestCaseCanceledEvent>();
-            var signedEvent = eiffelEvent?.Sign<EiffelTestCaseCanceledEvent>();
+            var eiffelEvent = TryClient.GetEvent<EiffelTestSuiteStartedEvent>();
+            var signedEvent = eiffelEvent?.Sign<EiffelTestSuiteStartedEvent>();
 
           /*for (int i = 0; i < 10000; i++)
            {*/

--- a/examples/EiffelClient.SubscriberOne/Program.cs
+++ b/examples/EiffelClient.SubscriberOne/Program.cs
@@ -41,8 +41,8 @@ namespace EiffelClient.SubscriberOne
             Console.WriteLine("Started ....");
 
             // Subscribe to events
-            _subscriptionId = _client.Subscribe<EiffelTestCaseCanceledEvent>(_queueIdentifier, GeneralHandleEvent);
-            Console.WriteLine($"Subscription done to event {nameof(EiffelTestCaseCanceledEvent)} !");
+            _subscriptionId = _client.Subscribe<EiffelTestSuiteStartedEvent>(_queueIdentifier, GeneralHandleEvent);
+            Console.WriteLine($"Subscription done to event {nameof(EiffelTestSuiteStartedEvent)} !");
 
             while (true)
             {

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelTestSuiteStartedEvent/EiffelTestSuiteStartedData.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelTestSuiteStartedEvent/EiffelTestSuiteStartedData.cs
@@ -1,0 +1,53 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using EiffelEvents.Net.Events.Core.Data;
+using EiffelEvents.Net.Events.Edition_Lyon.Shared.Data;
+using EiffelEvents.Net.Events.Edition_Paris.Shared.Enums;
+using EiffelEvents.Net.Validation;
+
+namespace EiffelEvents.Net.Events.Edition_Lyon
+{
+    public record EiffelTestSuiteStartedData : EiffelData
+    {
+        /// <summary>
+        /// The name of the test suite. Uniqueness is not required or checked, but is useful.
+        /// </summary>
+        [Required(AllowEmptyStrings = false)]
+        public string Name { get; init; }
+
+        /// <summary>
+        /// The category or categories of the test suite. This can be used to group multiple similar test suites for
+        /// analysis and visualization purposes. Example usage is to categorize test suites required before release
+        /// as "Pre-release tests".
+        /// </summary>
+        public List<string> Categories { get; init; }
+
+        /// <summary>
+        /// The type or types of testing performed by the test suite, as  defined by
+        /// <a href="http://www.softwaretestingstandard.org"> ISO 29119</a>
+        /// </summary>
+        public List<EiffelDataTestingType> Types { get; init; }
+
+        /// <summary>
+        /// An array of live log files available during execution. These shall not be presumed to be stored persistently;
+        /// in other words, once the test suite has finished there is no guarantee that these links are valid.
+        /// Persistently stored logs shall be (re-)declared by <see cref="EiffelTestSuiteFinishedEvent"/>
+        /// </summary>
+        [NestedList]
+        public List<EiffelLiveLog> LiveLogs { get; init; }
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelTestSuiteStartedEvent/EiffelTestSuiteStartedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelTestSuiteStartedEvent/EiffelTestSuiteStartedEvent.cs
@@ -1,0 +1,45 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using EiffelEvents.Net.Events.Core;
+using EiffelEvents.Net.Events.Edition_Lyon.Shared;
+
+namespace EiffelEvents.Net.Events.Edition_Lyon
+{
+    /// <summary>
+    /// The <a href="https://github.com/eiffel-community/eiffel/blob/edition-lyon/eiffel-vocabulary/EiffelTestS`uiteStartedEvent.md">
+    /// EiffelTestSuiteStartedEvent
+    /// </a> declares that the execution of a test suite has started. This can either be
+    /// declared stand-alone or as part of an activity or other test suite, using either a CAUSE or a CONTEXT link type,
+    /// respectively.
+    /// </summary>
+    public record EiffelTestSuiteStartedEvent :
+        EiffelEvent<EiffelTestSuiteStartedData, EiffelTestSuiteStartedMeta, EiffelTestSuiteStartedLinks>
+    {
+        /// <inheritdoc/>
+        public override EiffelTestSuiteStartedData Data { get; init; } = new();
+        
+        /// <inheritdoc/>
+        public override EiffelTestSuiteStartedMeta Meta { get; init; } = new();
+        
+        /// <inheritdoc/>
+        public override EiffelTestSuiteStartedLinks Links { get; init; } = new();
+        
+        /// <inheritdoc/>
+        public override IEiffelEvent FromJson(string json)
+        {
+            return Deserialize<EiffelTestSuiteStartedEvent>(json);
+        }
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelTestSuiteStartedEvent/EiffelTestSuiteStartedEvent.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelTestSuiteStartedEvent/EiffelTestSuiteStartedEvent.cs
@@ -18,7 +18,7 @@ using EiffelEvents.Net.Events.Edition_Lyon.Shared;
 namespace EiffelEvents.Net.Events.Edition_Lyon
 {
     /// <summary>
-    /// The <a href="https://github.com/eiffel-community/eiffel/blob/edition-lyon/eiffel-vocabulary/EiffelTestS`uiteStartedEvent.md">
+    /// The <a href="https://github.com/eiffel-community/eiffel/blob/edition-lyon/eiffel-vocabulary/EiffelTestSuiteStartedEvent.md">
     /// EiffelTestSuiteStartedEvent
     /// </a> declares that the execution of a test suite has started. This can either be
     /// declared stand-alone or as part of an activity or other test suite, using either a CAUSE or a CONTEXT link type,

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelTestSuiteStartedEvent/EiffelTestSuiteStartedLinks.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelTestSuiteStartedEvent/EiffelTestSuiteStartedLinks.cs
@@ -1,0 +1,31 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using EiffelEvents.Net.Events.Edition_Lyon.Shared;
+using EiffelEvents.Net.Events.Edition_Lyon.Shared.Links;
+using EiffelEvents.Net.Validation;
+
+namespace EiffelEvents.Net.Events.Edition_Lyon
+{
+    public record EiffelTestSuiteStartedLinks : EiffelSharedLinks
+    {
+        /// <summary>
+        /// This link signifies that the test suite represented by this event groups all test case executions resulting
+        /// from the EiffelTestExecutionRecipeCollectionCreatedEvent.
+        /// Legal targets: EiffelTestExecutionRecipeCollectionCreatedEvent
+        /// </summary>
+        [NestedObject]
+        public EiffelTercLink Terc { get; init; }
+    }
+}

--- a/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelTestSuiteStartedEvent/EiffelTestSuiteStartedMeta.cs
+++ b/src/EiffelEvents.Net/Events/Edition-Lyon/EiffelTestSuiteStartedEvent/EiffelTestSuiteStartedMeta.cs
@@ -1,0 +1,24 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using EiffelEvents.Net.Events.Edition_Lyon.Shared;
+
+namespace EiffelEvents.Net.Events.Edition_Lyon
+{
+    public record EiffelTestSuiteStartedMeta : EiffelSharedMeta
+    {
+        public override string Type { get; init; } = nameof(EiffelTestSuiteStartedEvent);
+        public override string Version { get; init; } = "3.2.0";
+    }
+}

--- a/tests/EiffelEvents.Net.Tests/Events/Edition-Lyon/EiffelTestSuiteStartedEventTests.cs
+++ b/tests/EiffelEvents.Net.Tests/Events/Edition-Lyon/EiffelTestSuiteStartedEventTests.cs
@@ -1,0 +1,92 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+using EiffelEvents.Net.Events.Edition_Lyon;
+using EiffelEvents.Net.Tests.TestData.Edition_Lyon;
+using FluentAssertions;
+using FluentResults;
+using Xunit;
+
+namespace EiffelEvents.Net.Tests.Events.Edition_Lyon
+{
+    public class EiffelTestSuiteStartedEventTests : IClassFixture<EiffelTestSuiteStartedEventFixture>
+    {
+        private readonly EiffelTestSuiteStartedEventFixture _eventFixture;
+
+        public EiffelTestSuiteStartedEventTests(EiffelTestSuiteStartedEventFixture fixture)
+        {
+            _eventFixture = fixture;
+        }
+        
+        [Fact]
+        public void Validate_CompleteAttributes_Success()
+        {
+            //Arrange
+            var testSuiteStartedEvent = _eventFixture.GetValidCompleteEvent();
+            
+            //Act
+            Result result = testSuiteStartedEvent.Validate();
+
+            //Assert
+            result.IsSuccess.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Validate_MissingRequired_Failed()
+        {
+            //Arrange
+            var testSuiteStartedEvent = new EiffelTestSuiteStartedEvent();
+
+            //Act
+            var result = testSuiteStartedEvent.Validate();
+
+            //Assert
+            result.IsSuccess.Should().BeFalse();
+        }
+        
+        [Fact]
+        public void VerifySignature_ValidSignature_Success()
+        {
+            //Arrange
+            var testSuiteStartedEvent = _eventFixture.GetValidCompleteEvent();
+
+            //Act
+            var testSuiteStartedEventSigned = testSuiteStartedEvent.Sign<EiffelTestSuiteStartedEvent>();
+
+            //Assert
+            testSuiteStartedEventSigned.VerifySignature().Should().BeTrue();
+        }
+
+        [Fact]
+        public void VerifySignature_CorruptedObject_Failed()
+        {
+            //Arrange
+            var testSuiteStartedEvent = _eventFixture.GetValidCompleteEvent();
+
+            //Act
+            var testSuiteStartedEventSigned = testSuiteStartedEvent.Sign<EiffelTestSuiteStartedEvent>();
+            testSuiteStartedEventSigned = testSuiteStartedEventSigned with
+            {
+                Meta = testSuiteStartedEventSigned.Meta with
+                {
+                    Id = Guid.NewGuid().ToString()
+                }
+            };
+            
+            //Assert
+            testSuiteStartedEventSigned.VerifySignature().Should().BeFalse();
+        }
+    }
+}

--- a/tests/EiffelEvents.Net.Tests/TestData/Edition-Lyon/EiffelTestSuiteStartedEventFixture.cs
+++ b/tests/EiffelEvents.Net.Tests/TestData/Edition-Lyon/EiffelTestSuiteStartedEventFixture.cs
@@ -1,0 +1,88 @@
+﻿//    Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using EiffelEvents.Net.Events.Edition_Lyon;
+using EiffelEvents.Net.Events.Edition_Paris.Shared.Enums;
+
+namespace EiffelEvents.Net.Tests.TestData.Edition_Lyon
+{
+    public class EiffelTestSuiteStartedEventFixture
+    {
+        /// <summary>
+        /// Get a complete valid instance of EiffelTestSuiteStartedEvent.
+        /// </summary>
+        /// <returns></returns>
+        public EiffelTestSuiteStartedEvent GetValidCompleteEvent()
+        {
+            return new EiffelTestSuiteStartedEvent
+            {
+                Data = new()
+                {
+                    Categories = new()
+                    {
+                        "category-1",
+                        "category-1"
+                    },
+                    LiveLogs = new()
+                    {
+                        new()
+                        {
+                            Name = "live-log-1",
+                            Uri = "livelog.xyz",
+                            MediaType = "Type 1",
+                            Tags = new() { "tag 1", "tag 2" }
+                        }
+                    },
+                    Name = "test-suite-1",
+                    Types = new()
+                    {
+                        EiffelDataTestingType.USABILITY,
+                        EiffelDataTestingType.SECURITY
+                    },
+                    CustomData = new()
+                    {
+                        { "key1", "test" },
+                        { "key2", new[] { 1, 2, 3 } }
+                    }
+                },
+                Meta = new()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Tags = new List<string> { "docker env" },
+                    Security = new()
+                    {
+                        AuthorIdentity = "Flower"
+                    }
+                },
+                Links = new()
+                {
+                    Terc = new(Guid.NewGuid().ToString()),
+                    Cause = new()
+                    {
+                        new(Guid.NewGuid().ToString()),
+                        new(Guid.NewGuid().ToString())
+                    },
+                    Context = new(Guid.NewGuid().ToString()),
+                    FlowContext = new()
+                    {
+                        new(Guid.NewGuid().ToString()),
+                        new(Guid.NewGuid().ToString())
+                    }
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
### Applicable Issues
This PR resolves #38.

### Description of the Change
- Add EiffelTestSuiteStartedEvent Lyon edition.
- Add EiffelTestSuiteStartedEventLyon edition test.
- Add EiffelTestSuiteStartedEventLyon edition examples.

### Benefits
Support Lyon edition.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fady Kamil engfadykamil.2014@gmail.com
