### PR TITLE
Fix queue durability

### DIFF
--- a/docs/docfx_project/articles/architecture-rabbitmq-client.md
+++ b/docs/docfx_project/articles/architecture-rabbitmq-client.md
@@ -73,7 +73,16 @@ Queue name will be auto-generated with the following pattern: `"{serviceName}_{e
 
 As a result of that design, once an event is published to a certain Topic (XEvent), only one **XService** instance will process that event hence RabbitMQ will push the messages from the queue to the service using a round-robin pattern. Once the event will be dequeued by a service instance (XService instance 1), the other two instances will not be able to process that event.
 
-## RabbitMqEiffelClient Functionality
+### Queues Durability
+We have designed our RabbitMQ client to declare queues using the following parameters:
+- `durable: true` => configure declared queue as durable after RabbitMQ instance restart.
+- `exclusive: false` => configure declared queue as persistent after the declaring connection is closed.
+- `autoDelete: false` => configure declared queue as persistent after the consumer unsubscribes.
+
+This will make the consumer capable of consuming events published in its downtime as the queue will be durable and messages will be persistent on RabbitMQ instance. 
+
+
+## `RabbitMqEiffelClient`
 
 `RabbitMqEiffelClient` is the core class used for assisted publishing and subscribing to RabbitMQ, it implements the `IEiffelClient` interface which resides in the **EiffelEvents** package, and sets the contract for Eiffel Clients classes such as `RabbitMqEiffelClient`.
 
@@ -215,7 +224,6 @@ where:
 ## RabbitMqWrapper
 
 `RabbitMqWrapper` as its name implies, wraps and abstract all RabbitMQ client functionality to `RabbitMqEiffelClient`
-
 to ease further updates and maintainability.
 
 ## Exception

--- a/src/EiffelEvents.RabbitMq.Client/Common/RabbitMqWrapper.cs
+++ b/src/EiffelEvents.RabbitMq.Client/Common/RabbitMqWrapper.cs
@@ -148,7 +148,7 @@ namespace EiffelEvents.RabbitMq.Client.Common
         {
             //Declare the Queue
             var createdQueue =
-                _channel.QueueDeclare(queueName, durable: false, exclusive: false, autoDelete: true, null);
+                _channel.QueueDeclare(queueName, durable: true, exclusive: false, autoDelete: false, null);
             //Bind the Queue to the Exchange
             _channel.QueueBind(createdQueue.QueueName, exchangeName, routingKey, null);
             _channel.BasicQos(0, 1, false);


### PR DESCRIPTION
### Applicable Issues
This PR resolves #73.

### Description of the Change
Configure durable queues, that will allow consumer service to consume events that are published in its downtime after it became live again.

### Benefits
Consumer services will have the ability to process the events that happen in their downtime.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fady Kamil engfadykamil.2014@gmail.com
