### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/docs/docfx_project/articles/architecture-rabbitmq-client.md
+++ b/docs/docfx_project/articles/architecture-rabbitmq-client.md
@@ -164,7 +164,7 @@ Result<T> Publish<T>(T eiffelEvent) where T : IEiffelEvent;
 Subscribes to events of the given type (the given topic). the `Subscribe` method has the following signature:
 
 ```c#
-string Subscribe<T>(string serviceIdentifier, Action<Result<T>, ulong> callback, SchemaValidationOnSubscribe validateOnSubscribe) where T : IEiffelEvent, new();
+string Subscribe<T>(string serviceIdentifier, Action<Result<T>, ulong> callback, SchemaValidationOnSubscribe validateOnSubscribe) where T : IEiffelEvent;
 ```
 
 where: 
@@ -177,7 +177,7 @@ where:
 
 Note: the following overload also exist for `Subscribe` but `SchemaValidationOnSubscribe` will be `NONE` by default configurations if user didn't pass it in `ClientConfig`, otherwise, it will depend on the value configured in `ClientConfig` that passed to the constructor of `RabbitMqEiffelClient`
 ```c#
-string Subscribe<T>(string serviceIdentifier, Action<Result<T>, ulong> callback) where T : IEiffelEvent, new();
+string Subscribe<T>(string serviceIdentifier, Action<Result<T>, ulong> callback) where T : IEiffelEvent;
 ```
 
 ***Note:** all events (i.e. messages) that will be processed must be acknowledged if the processing is done successfully or rejected if any unhandled situation happens while processing.*

--- a/src/EiffelEvents.Clients.RabbitMq/RabbitMqEiffelClient.cs
+++ b/src/EiffelEvents.Clients.RabbitMq/RabbitMqEiffelClient.cs
@@ -53,7 +53,7 @@ namespace EiffelEvents.Clients.RabbitMq
 
         /// <inheritdoc/>
         public Result<T> Publish<T>(T eiffelEvent, SchemaValidationOnPublish validateOnPublish)
-            where T : IEiffelEvent, new()
+            where T : IEiffelEvent
         {
             try
             {
@@ -105,7 +105,7 @@ namespace EiffelEvents.Clients.RabbitMq
         /// If publish succeed, result object will hold event sent on the bus,
         /// which may be different from the input event (e.g. signed).
         /// </returns>
-        public Result<T> Publish<T>(T eiffelEvent) where T : IEiffelEvent, new()
+        public Result<T> Publish<T>(T eiffelEvent) where T : IEiffelEvent
         {
             return Publish(eiffelEvent, _validationConfig.SchemaValidationOnPublish);
         }
@@ -128,14 +128,14 @@ namespace EiffelEvents.Clients.RabbitMq
         /// </param>
         /// <returns>string for subscriptionId can later be used to UnSubscribe</returns>
         public string Subscribe<T>(string serviceIdentifier, Action<Result<T>, ulong> callback)
-            where T : IEiffelEvent, new()
+            where T : IEiffelEvent
         {
             return Subscribe(serviceIdentifier, callback, _validationConfig.SchemaValidationOnSubscribe);
         }
 
         /// <inheritdoc/>
         public string Subscribe<T>(string serviceIdentifier, Action<Result<T>, ulong> callback,
-            SchemaValidationOnSubscribe validateOnSubscribe) where T : IEiffelEvent, new()
+            SchemaValidationOnSubscribe validateOnSubscribe) where T : IEiffelEvent
         {
             try
             {
@@ -185,7 +185,7 @@ namespace EiffelEvents.Clients.RabbitMq
         /// was succeeded. Result.Errors will hold the error messages in case of failures.
         /// </returns>
         private Result<T> TryDeserializeEvent<T>(SchemaValidationOnSubscribe validateOnSubscribe, T typeObj, string content)
-            where T : IEiffelEvent, new()
+            where T : IEiffelEvent
         {
             var (type, version) = JsonHelper.GetTypeAndVersion(content);
 
@@ -231,7 +231,7 @@ namespace EiffelEvents.Clients.RabbitMq
             }
         }
 
-        private Result<T> GetResultFromValidationErrors<T>(Result validJsonResult) where T : IEiffelEvent, new()
+        private Result<T> GetResultFromValidationErrors<T>(Result validJsonResult) where T : IEiffelEvent
         {
             var errorMessage = "JSON validation against the corresponding JSON schema was failed. ";
             var validationErrors = string.Join(", ", validJsonResult.Errors.Select(x => x.Message));

--- a/src/EiffelEvents.Net/Clients/IEiffelClient.cs
+++ b/src/EiffelEvents.Net/Clients/IEiffelClient.cs
@@ -39,7 +39,7 @@ namespace EiffelEvents.Net.Clients
         /// If publish succeed, result object will hold event sent on the bus,
         /// which may be different from the input event (e.g. signed).
         /// </returns>
-        Result<T> Publish<T>(T eiffelEvent, SchemaValidationOnPublish validateOnPublish) where T : IEiffelEvent, new();
+        Result<T> Publish<T>(T eiffelEvent, SchemaValidationOnPublish validateOnPublish) where T : IEiffelEvent;
 
         /// <summary>
         /// Publish an event to the Eiffel event bus represented by this client. SchemaValidationOnPublish will be ON
@@ -53,7 +53,7 @@ namespace EiffelEvents.Net.Clients
         /// If publish succeed, result object will hold event sent on the bus,
         /// which may be different from the input event (e.g. signed).
         /// </returns>
-        Result<T> Publish<T>(T eiffelEvent) where T : IEiffelEvent, new();
+        Result<T> Publish<T>(T eiffelEvent) where T : IEiffelEvent;
 
         /// <summary>
         /// Subscribes to events of the given Eiffel type. SchemaValidationOnSubscribe will be NONE by default
@@ -70,7 +70,7 @@ namespace EiffelEvents.Net.Clients
         /// And, ulong for deliveryTag.
         /// </param>
         /// <returns>string for subscriptionId can later be used to UnSubscribe</returns>
-        string Subscribe<T>(string serviceIdentifier, Action<Result<T>, ulong> callback) where T : IEiffelEvent, new();
+        string Subscribe<T>(string serviceIdentifier, Action<Result<T>, ulong> callback) where T : IEiffelEvent;
 
         /// <summary>
         /// Subscribes to events of the given Eiffel type
@@ -88,7 +88,7 @@ namespace EiffelEvents.Net.Clients
         /// <typeparam name="T">Type of event to subscribe to</typeparam>
         /// <returns>string for subscriptionId can later be used to UnSubscribe</returns>
         string Subscribe<T>(string serviceIdentifier, Action<Result<T>, ulong> callback,
-            SchemaValidationOnSubscribe validateOnSubscribe) where T : IEiffelEvent, new();
+            SchemaValidationOnSubscribe validateOnSubscribe) where T : IEiffelEvent;
 
         /// <summary>
         /// Acknowledge receiving the message(event), used for positive acknowledgements. 


### PR DESCRIPTION
### Applicable Issues
This PR resolves #85 

### Description of the Change
Remove unnecessary parameterless constructor constraints from `Publish` and `Subscribe` methods in `IEiffelClient` and `EiffelEvents.Clients.RabbitMQ` as it implements `IEiffelClient`.

### Benefits
Make the codebase clean and remove not needed constraints.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fady Kamil engfadykamil.2014@gmail.com
