### PR TITLE
Fix get event type

### DIFF
--- a/examples/EiffelClient.SubscriberOne/Program.cs
+++ b/examples/EiffelClient.SubscriberOne/Program.cs
@@ -51,7 +51,8 @@ namespace EiffelClient.SubscriberOne
             Console.WriteLine("Started ....");
 
             // Subscribe to events
-            _subscriptionId = _client.Subscribe<EiffelActivityTriggeredEvent>(_queueIdentifier, GeneralHandleEvent);
+            _subscriptionId =
+                _client.Subscribe(typeof(EiffelActivityTriggeredEvent), _queueIdentifier, GeneralHandleEvent);
 
             // or subscribe to event with overriding the global configurations of SchemaValidationOnSubscribe
             // _subscriptionId = _client.Subscribe<EiffelActivityTriggeredEvent>(_queueIdentifier, GeneralHandleEvent, SchemaValidationOnSubscribe.ON_DESERIALIZATION_FAIL);

--- a/src/EiffelEvents.Net/Clients/IEiffelClient.cs
+++ b/src/EiffelEvents.Net/Clients/IEiffelClient.cs
@@ -91,6 +91,43 @@ namespace EiffelEvents.Net.Clients
             SchemaValidationOnSubscribe validateOnSubscribe) where T : IEiffelEvent;
 
         /// <summary>
+        /// Subscribes to events of the given Eiffel type.
+        /// </summary>
+        /// <param name="eventType">Type of Eiffel event.</param>
+        /// <param name="serviceIdentifier">string identifier for each service to be included in queue name</param>
+        /// <param name="callback">
+        /// Callback that will be invoked when new events are received where
+        /// <see cref="Result{TValue}"/> is Fluent result object of subscribed event. "IsSuccess" flag will be "true"
+        /// if the received JSON was a valid event according to the respective schema and the event object can be found
+        /// in "Value" property. "IsSuccess" flag will be "false" if the received JSON wasn't valid according to the
+        /// respective schema and the validation errors can be found using `Errors` property.
+        /// And, ulong for deliveryTag.
+        /// </param>
+        /// <param name="validateOnSubscribe">States when to validate the received JSON event</param>
+        /// <returns>string for subscriptionId can later be used to UnSubscribe</returns>
+        public string Subscribe(Type eventType, string serviceIdentifier,
+            Action<Result<IEiffelEvent>, ulong> callback,
+            SchemaValidationOnSubscribe validateOnSubscribe);
+        
+        /// <summary>
+        /// Subscribes to events of the given Eiffel type. SchemaValidationOnSubscribe will be NONE by default
+        /// configurations.
+        /// </summary>
+        /// <param name="eventType">Type of Eiffel event.</param>
+        /// <param name="serviceIdentifier">string identifier for each service to be included in queue name</param>
+        /// <param name="callback">
+        /// Callback that will be invoked when new events are received where
+        /// <see cref="Result{TValue}"/> is Fluent result object of subscribed event. "IsSuccess" flag will be "true"
+        /// if the received JSON was a valid event according to the respective schema and the event object can be found
+        /// in "Value" property. "IsSuccess" flag will be "false" if the received JSON wasn't valid according to the
+        /// respective schema and the validation errors can be found using `Errors` property.
+        /// And, ulong for deliveryTag.
+        /// </param>
+        /// <returns>string for subscriptionId can later be used to UnSubscribe</returns>
+        public string Subscribe(Type eventType, string serviceIdentifier,
+            Action<Result<IEiffelEvent>, ulong> callback);
+
+        /// <summary>
         /// Acknowledge receiving the message(event), used for positive acknowledgements. 
         /// </summary>
         /// <param name="deliveryTag">A growing positive integers uniquely identifies the delivery on a channel.</param>


### PR DESCRIPTION
### Applicable Issues
This PR resolves #86 

### Description of the Change
- Fix the issue of getting the event type in the `Publish` method to get the event type from the passed object itself instead of using the passed generic type.
- Add overload to the `Subscribe` method to pass the event type as method param rather than type param.

### Benefits
This will help the SDK to get the real event type instead of the generic type passed to the `Publish` method that can be abstract also.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fady Kamil engfadykamil.2014@gmail.com
