### PR TITLE
packaging v 1.0.3

### DIFF
--- a/docs/docfx_project/articles/architecture-rabbitmq-client.md
+++ b/docs/docfx_project/articles/architecture-rabbitmq-client.md
@@ -164,7 +164,7 @@ Result<T> Publish<T>(T eiffelEvent) where T : IEiffelEvent;
 Subscribes to events of the given type (the given topic). the `Subscribe` method has the following signature:
 
 ```c#
-string Subscribe<T>(string serviceIdentifier, Action<Result<T>, ulong> callback, SchemaValidationOnSubscribe validateOnSubscribe) where T : IEiffelEvent, new();
+string Subscribe<T>(string serviceIdentifier, Action<Result<T>, ulong> callback, SchemaValidationOnSubscribe validateOnSubscribe) where T : IEiffelEvent;
 ```
 
 where: 
@@ -177,7 +177,7 @@ where:
 
 Note: the following overload also exist for `Subscribe` but `SchemaValidationOnSubscribe` will be `NONE` by default configurations if user didn't pass it in `ClientConfig`, otherwise, it will depend on the value configured in `ClientConfig` that passed to the constructor of `RabbitMqEiffelClient`
 ```c#
-string Subscribe<T>(string serviceIdentifier, Action<Result<T>, ulong> callback) where T : IEiffelEvent, new();
+string Subscribe<T>(string serviceIdentifier, Action<Result<T>, ulong> callback) where T : IEiffelEvent;
 ```
 
 ***Note:** all events (i.e. messages) that will be processed must be acknowledged if the processing is done successfully or rejected if any unhandled situation happens while processing.*

--- a/examples/EiffelClient.SubscriberOne/Program.cs
+++ b/examples/EiffelClient.SubscriberOne/Program.cs
@@ -51,7 +51,8 @@ namespace EiffelClient.SubscriberOne
             Console.WriteLine("Started ....");
 
             // Subscribe to events
-            _subscriptionId = _client.Subscribe<EiffelActivityTriggeredEvent>(_queueIdentifier, GeneralHandleEvent);
+            _subscriptionId =
+                _client.Subscribe(typeof(EiffelActivityTriggeredEvent), _queueIdentifier, GeneralHandleEvent);
 
             // or subscribe to event with overriding the global configurations of SchemaValidationOnSubscribe
             // _subscriptionId = _client.Subscribe<EiffelActivityTriggeredEvent>(_queueIdentifier, GeneralHandleEvent, SchemaValidationOnSubscribe.ON_DESERIALIZATION_FAIL);

--- a/src/EiffelEvents.Clients.RabbitMq/EiffelEvents.Clients.RabbitMq.csproj
+++ b/src/EiffelEvents.Clients.RabbitMq/EiffelEvents.Clients.RabbitMq.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
-        <Version>1.0.2</Version>
+        <Version>1.0.3</Version>
         <RootNamespace>EiffelEvents.Clients.RabbitMq</RootNamespace>
     </PropertyGroup>
     

--- a/src/EiffelEvents.Clients.RabbitMq/EiffelEvents.Clients.RabbitMq.nuspec
+++ b/src/EiffelEvents.Clients.RabbitMq/EiffelEvents.Clients.RabbitMq.nuspec
@@ -13,12 +13,13 @@
         </description>
         <copyright>Copyright (c) 2021 ICT Cube, doWhile, and Eiffel Community collaborators</copyright>
         <dependencies>
-            <dependency id="EiffelEvents.Net" version="1.0.2" />
+            <dependency id="EiffelEvents.Net" version="1.0.3" />
             <dependency id="Newtonsoft.Json" version="13.0.1" />
             <dependency id="RabbitMQ.Client" version="6.2.2" />
         </dependencies>
         <releaseNotes>
-            Upgrade dependencies (EiffelEvents.Net) to its latest versions
+            Remove unnecessary parameterless constructor constraints in RabbitMqEiffelClient.
+            Add more overloads for subscribe method in RabbitMqEiffelClient.
         </releaseNotes>
     </metadata>
     <files>

--- a/src/EiffelEvents.Clients.RabbitMq/RabbitMqEiffelClient.cs
+++ b/src/EiffelEvents.Clients.RabbitMq/RabbitMqEiffelClient.cs
@@ -53,7 +53,7 @@ namespace EiffelEvents.Clients.RabbitMq
 
         /// <inheritdoc/>
         public Result<T> Publish<T>(T eiffelEvent, SchemaValidationOnPublish validateOnPublish)
-            where T : IEiffelEvent, new()
+            where T : IEiffelEvent
         {
             try
             {
@@ -105,7 +105,7 @@ namespace EiffelEvents.Clients.RabbitMq
         /// If publish succeed, result object will hold event sent on the bus,
         /// which may be different from the input event (e.g. signed).
         /// </returns>
-        public Result<T> Publish<T>(T eiffelEvent) where T : IEiffelEvent, new()
+        public Result<T> Publish<T>(T eiffelEvent) where T : IEiffelEvent
         {
             return Publish(eiffelEvent, _validationConfig.SchemaValidationOnPublish);
         }
@@ -128,14 +128,14 @@ namespace EiffelEvents.Clients.RabbitMq
         /// </param>
         /// <returns>string for subscriptionId can later be used to UnSubscribe</returns>
         public string Subscribe<T>(string serviceIdentifier, Action<Result<T>, ulong> callback)
-            where T : IEiffelEvent, new()
+            where T : IEiffelEvent
         {
             return Subscribe(serviceIdentifier, callback, _validationConfig.SchemaValidationOnSubscribe);
         }
 
         /// <inheritdoc/>
         public string Subscribe<T>(string serviceIdentifier, Action<Result<T>, ulong> callback,
-            SchemaValidationOnSubscribe validateOnSubscribe) where T : IEiffelEvent, new()
+            SchemaValidationOnSubscribe validateOnSubscribe) where T : IEiffelEvent
         {
             try
             {
@@ -185,7 +185,7 @@ namespace EiffelEvents.Clients.RabbitMq
         /// was succeeded. Result.Errors will hold the error messages in case of failures.
         /// </returns>
         private Result<T> TryDeserializeEvent<T>(SchemaValidationOnSubscribe validateOnSubscribe, T typeObj, string content)
-            where T : IEiffelEvent, new()
+            where T : IEiffelEvent
         {
             var (type, version) = JsonHelper.GetTypeAndVersion(content);
 
@@ -231,7 +231,7 @@ namespace EiffelEvents.Clients.RabbitMq
             }
         }
 
-        private Result<T> GetResultFromValidationErrors<T>(Result validJsonResult) where T : IEiffelEvent, new()
+        private Result<T> GetResultFromValidationErrors<T>(Result validJsonResult) where T : IEiffelEvent
         {
             var errorMessage = "JSON validation against the corresponding JSON schema was failed. ";
             var validationErrors = string.Join(", ", validJsonResult.Errors.Select(x => x.Message));

--- a/src/EiffelEvents.Net/Clients/IEiffelClient.cs
+++ b/src/EiffelEvents.Net/Clients/IEiffelClient.cs
@@ -91,6 +91,43 @@ namespace EiffelEvents.Net.Clients
             SchemaValidationOnSubscribe validateOnSubscribe) where T : IEiffelEvent;
 
         /// <summary>
+        /// Subscribes to events of the given Eiffel type.
+        /// </summary>
+        /// <param name="eventType">Type of Eiffel event.</param>
+        /// <param name="serviceIdentifier">string identifier for each service to be included in queue name</param>
+        /// <param name="callback">
+        /// Callback that will be invoked when new events are received where
+        /// <see cref="Result{TValue}"/> is Fluent result object of subscribed event. "IsSuccess" flag will be "true"
+        /// if the received JSON was a valid event according to the respective schema and the event object can be found
+        /// in "Value" property. "IsSuccess" flag will be "false" if the received JSON wasn't valid according to the
+        /// respective schema and the validation errors can be found using `Errors` property.
+        /// And, ulong for deliveryTag.
+        /// </param>
+        /// <param name="validateOnSubscribe">States when to validate the received JSON event</param>
+        /// <returns>string for subscriptionId can later be used to UnSubscribe</returns>
+        public string Subscribe(Type eventType, string serviceIdentifier,
+            Action<Result<IEiffelEvent>, ulong> callback,
+            SchemaValidationOnSubscribe validateOnSubscribe);
+        
+        /// <summary>
+        /// Subscribes to events of the given Eiffel type. SchemaValidationOnSubscribe will be NONE by default
+        /// configurations.
+        /// </summary>
+        /// <param name="eventType">Type of Eiffel event.</param>
+        /// <param name="serviceIdentifier">string identifier for each service to be included in queue name</param>
+        /// <param name="callback">
+        /// Callback that will be invoked when new events are received where
+        /// <see cref="Result{TValue}"/> is Fluent result object of subscribed event. "IsSuccess" flag will be "true"
+        /// if the received JSON was a valid event according to the respective schema and the event object can be found
+        /// in "Value" property. "IsSuccess" flag will be "false" if the received JSON wasn't valid according to the
+        /// respective schema and the validation errors can be found using `Errors` property.
+        /// And, ulong for deliveryTag.
+        /// </param>
+        /// <returns>string for subscriptionId can later be used to UnSubscribe</returns>
+        public string Subscribe(Type eventType, string serviceIdentifier,
+            Action<Result<IEiffelEvent>, ulong> callback);
+
+        /// <summary>
         /// Acknowledge receiving the message(event), used for positive acknowledgements. 
         /// </summary>
         /// <param name="deliveryTag">A growing positive integers uniquely identifies the delivery on a channel.</param>

--- a/src/EiffelEvents.Net/Clients/IEiffelClient.cs
+++ b/src/EiffelEvents.Net/Clients/IEiffelClient.cs
@@ -39,7 +39,7 @@ namespace EiffelEvents.Net.Clients
         /// If publish succeed, result object will hold event sent on the bus,
         /// which may be different from the input event (e.g. signed).
         /// </returns>
-        Result<T> Publish<T>(T eiffelEvent, SchemaValidationOnPublish validateOnPublish) where T : IEiffelEvent, new();
+        Result<T> Publish<T>(T eiffelEvent, SchemaValidationOnPublish validateOnPublish) where T : IEiffelEvent;
 
         /// <summary>
         /// Publish an event to the Eiffel event bus represented by this client. SchemaValidationOnPublish will be ON
@@ -53,7 +53,7 @@ namespace EiffelEvents.Net.Clients
         /// If publish succeed, result object will hold event sent on the bus,
         /// which may be different from the input event (e.g. signed).
         /// </returns>
-        Result<T> Publish<T>(T eiffelEvent) where T : IEiffelEvent, new();
+        Result<T> Publish<T>(T eiffelEvent) where T : IEiffelEvent;
 
         /// <summary>
         /// Subscribes to events of the given Eiffel type. SchemaValidationOnSubscribe will be NONE by default
@@ -70,7 +70,7 @@ namespace EiffelEvents.Net.Clients
         /// And, ulong for deliveryTag.
         /// </param>
         /// <returns>string for subscriptionId can later be used to UnSubscribe</returns>
-        string Subscribe<T>(string serviceIdentifier, Action<Result<T>, ulong> callback) where T : IEiffelEvent, new();
+        string Subscribe<T>(string serviceIdentifier, Action<Result<T>, ulong> callback) where T : IEiffelEvent;
 
         /// <summary>
         /// Subscribes to events of the given Eiffel type
@@ -88,7 +88,7 @@ namespace EiffelEvents.Net.Clients
         /// <typeparam name="T">Type of event to subscribe to</typeparam>
         /// <returns>string for subscriptionId can later be used to UnSubscribe</returns>
         string Subscribe<T>(string serviceIdentifier, Action<Result<T>, ulong> callback,
-            SchemaValidationOnSubscribe validateOnSubscribe) where T : IEiffelEvent, new();
+            SchemaValidationOnSubscribe validateOnSubscribe) where T : IEiffelEvent;
 
         /// <summary>
         /// Acknowledge receiving the message(event), used for positive acknowledgements. 

--- a/src/EiffelEvents.Net/EiffelEvents.Net.csproj
+++ b/src/EiffelEvents.Net/EiffelEvents.Net.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>disable</Nullable>
-        <Version>1.0.2</Version>
+        <Version>1.0.3</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/EiffelEvents.Net/EiffelEvents.Net.nuspec
+++ b/src/EiffelEvents.Net/EiffelEvents.Net.nuspec
@@ -19,7 +19,8 @@
             <dependency id="Newtonsoft.Json.Schema" version="3.0.14"/>
         </dependencies>
         <releaseNotes>
-            Upgrade dependency (FluentResults) to its latest versions
+            Remove unnecessary parameterless constructor constraints in IEiffelClient.
+            Add more overloads for subscribe method in IEiffelClient.
         </releaseNotes>
     </metadata>
     <files>

--- a/tests/EiffelEvents.Net.Tests/Helpers/VersionHelper.cs
+++ b/tests/EiffelEvents.Net.Tests/Helpers/VersionHelper.cs
@@ -16,5 +16,5 @@ namespace EiffelEvents.Net.Tests.Helpers;
 
 public static class VersionHelper
 {
-    public static string Version => "1.0.2";
+    public static string Version => "1.0.3";
 }


### PR DESCRIPTION

### Description of the Change
- Fix the issue of getting the event type in the `Publish` method to get the event type from the passed object itself instead of using the passed generic type.
- Add overload to the `Subscribe` method to pass the event type as method param rather than type param.
- Remove unnecessary parameterless constructor constraints from `Publish` and `Subscribe` methods in `IEiffelClient` and `EiffelEvents.Clients.RabbitMQ` as it implements `IEiffelClient`.

### Benefits
- This will help the SDK to get the real event type instead of the generic type passed to the Publish method that can be abstract also.
- Make the codebase clean and remove not needed constraints.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fady Kamil engfadykamil.2014@gmail.com
